### PR TITLE
Add Comprehensive Right-Click Context Menus

### DIFF
--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -125,7 +125,7 @@ final class ContentManager {
         markSelectedDirty()
     }
     
-    private func selectFolderChildren(_ folderId: UUID) {
+    func selectFolderChildren(_ folderId: UUID) {
         guard let folderItem = allItems.first(where: { $0.id == folderId }),
               folderItem.isFolder,
               let folderPath = folderItem.fileURL?.path else { return }
@@ -149,7 +149,7 @@ final class ContentManager {
         markSelectedDirty()
     }
     
-    private func deselectFolderChildren(_ folderId: UUID) {
+    func deselectFolderChildren(_ folderId: UUID) {
         guard let folderItem = allItems.first(where: { $0.id == folderId }),
               folderItem.isFolder,
               let folderPath = folderItem.fileURL?.path else { return }
@@ -314,8 +314,8 @@ final class ContentManager {
     }
     
     func toggleExample(_ id: UUID) {
-        // Only allow toggling example state for selected, textual items
-        guard canToggleExample(id) else { return }
+        // Allow toggling example state for any textual items (no need to be selected as context)
+        guard isTextualItem(id) else { return }
         guard let item = allItems.first(where: { $0.id == id }) else { return }
         if exampleItemIds.contains(id) {
             // Turning OFF example: clear on folder and its descendants
@@ -392,6 +392,12 @@ final class ContentManager {
     func canToggleExample(_ id: UUID) -> Bool {
         guard selectedItemIds.contains(id),
               let item = allItems.first(where: { $0.id == id }) else { return false }
+        
+        return isTextualItem(id)
+    }
+    
+    func isTextualItem(_ id: UUID) -> Bool {
+        guard let item = allItems.first(where: { $0.id == id }) else { return false }
         
         if item.isFolder {
             // Allow folder examples only if all descendant files are textual and there is at least one file

--- a/nozzle/Observables/FileSystemSource.swift
+++ b/nozzle/Observables/FileSystemSource.swift
@@ -4,6 +4,20 @@ import CryptoKit
 import Observation
 import CoreServices
 
+// MARK: - Sorting Enums
+
+enum FileSortOrder: String, CaseIterable {
+    case name = "name"
+    case dateModified = "dateModified"
+    case size = "size"
+    case type = "type"
+}
+
+enum FileSortDirection: String, CaseIterable {
+    case ascending = "ascending"
+    case descending = "descending"
+}
+
 @Observable @MainActor
 final class FileSystemSource: ContentSource {
     nonisolated let id: String  // Need nonisolated access for event persistence
@@ -18,6 +32,10 @@ final class FileSystemSource: ContentSource {
     
     var isMonitoring: Bool = false
     var searchQuery: String = ""
+    
+    // Sorting configuration
+    var sortOrder: FileSortOrder = .name
+    var sortDirection: FileSortDirection = .ascending
     
     // FSEvents monitoring
     private var stream: FSEventsStream?
@@ -208,8 +226,11 @@ final class FileSystemSource: ContentSource {
             }
             
             // Sort folders first, then files
-            folders.sort { $0.lastPathComponent.localizedCompare($1.lastPathComponent) == .orderedAscending }
-            files.sort { $0.lastPathComponent.localizedCompare($1.lastPathComponent) == .orderedAscending }
+            let sortOrder = await MainActor.run { self.sortOrder }
+            let sortDirection = await MainActor.run { self.sortDirection }
+            
+            folders.sort { self.sortFiles($0, $1, order: sortOrder, direction: sortDirection) }
+            files.sort { self.sortFiles($0, $1, order: sortOrder, direction: sortDirection) }
             
             // Add folders
             for folderURL in folders {
@@ -317,6 +338,42 @@ final class FileSystemSource: ContentSource {
     
     func isFolderExpanded(at path: String) -> Bool {
         expansionState.isExpanded(path)
+    }
+    
+    // MARK: - Sorting Methods
+    
+    func setSortOrder(_ order: FileSortOrder, direction: FileSortDirection) {
+        sortOrder = order
+        sortDirection = direction
+        Task {
+            await refresh()
+        }
+    }
+    
+    private nonisolated func sortFiles(_ file1: URL, _ file2: URL, order: FileSortOrder, direction: FileSortDirection) -> Bool {
+        let result: Bool
+        
+        switch order {
+        case .name:
+            result = file1.lastPathComponent.localizedCompare(file2.lastPathComponent) == .orderedAscending
+            
+        case .dateModified:
+            let date1 = (try? file1.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? Date.distantPast
+            let date2 = (try? file2.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? Date.distantPast
+            result = date1 < date2
+            
+        case .size:
+            let size1 = (try? file1.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+            let size2 = (try? file2.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+            result = size1 < size2
+            
+        case .type:
+            let ext1 = file1.pathExtension.lowercased()
+            let ext2 = file2.pathExtension.lowercased()
+            result = ext1.localizedCompare(ext2) == .orderedAscending
+        }
+        
+        return direction == .ascending ? result : !result
     }
 }
 

--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -175,7 +175,8 @@ struct ContentView: View {
                     if selectedTab == src.id {
                       selectedTab = "clipboard"
                     }
-                  } : nil
+                  } : nil,
+                  source: src
                 )
               }
               
@@ -271,6 +272,34 @@ struct ContentView: View {
                 .frame(minWidth: 300, maxWidth: .infinity)
               } else {
                 ListView(contextItems: contextItems, exampleItems: exampleItems)
+                  .contextMenu {
+                    Button("Copy All") {
+                      appState.performCombinedPaste()
+                    }
+                    
+                    Button("Clear Selection") {
+                      contentManager.clearSelection()
+                      appState.updateFooterItemVisibility()
+                    }
+                    
+                    Divider()
+                    
+                    if !contextItems.isEmpty {
+                      Button("Convert All to Examples") {
+                        for item in contextItems {
+                          contentManager.toggleExample(item.id)
+                        }
+                      }
+                    }
+                    
+                    if !exampleItems.isEmpty {
+                      Button("Convert All to Context") {
+                        for item in exampleItems {
+                          contentManager.toggleExample(item.id)
+                        }
+                      }
+                    }
+                  }
                   .frame(minWidth: 300)
               }
             } else {
@@ -431,13 +460,15 @@ struct TabButton: View {
   let showCloseButton: Bool
   let action: () -> Void
   let onClose: (() -> Void)?
+  let source: (any ContentSource)?
   
-  init(title: String, isSelected: Bool, showCloseButton: Bool = false, action: @escaping () -> Void, onClose: (() -> Void)? = nil) {
+  init(title: String, isSelected: Bool, showCloseButton: Bool = false, action: @escaping () -> Void, onClose: (() -> Void)? = nil, source: (any ContentSource)? = nil) {
     self.title = title
     self.isSelected = isSelected
     self.showCloseButton = showCloseButton
     self.action = action
     self.onClose = onClose
+    self.source = source
   }
   
   var body: some View {
@@ -458,7 +489,50 @@ struct TabButton: View {
       .buttonStyle(PlainButtonStyle())
       // Right-click context menu for deletable tabs
       .contextMenu {
-        if showCloseButton {
+        if let fileSystemSource = source as? FileSystemSource {
+          // Enhanced context menu for folder tabs
+          Menu("Sort By") {
+            Button(fileSystemSource.sortOrder == .name && fileSystemSource.sortDirection == .ascending ? "✓ Name (A-Z)" : "Name (A-Z)") {
+              fileSystemSource.setSortOrder(.name, direction: .ascending)
+            }
+            Button(fileSystemSource.sortOrder == .name && fileSystemSource.sortDirection == .descending ? "✓ Name (Z-A)" : "Name (Z-A)") {
+              fileSystemSource.setSortOrder(.name, direction: .descending)
+            }
+            Button(fileSystemSource.sortOrder == .dateModified && fileSystemSource.sortDirection == .descending ? "✓ Date Modified (Newest First)" : "Date Modified (Newest First)") {
+              fileSystemSource.setSortOrder(.dateModified, direction: .descending)
+            }
+            Button(fileSystemSource.sortOrder == .dateModified && fileSystemSource.sortDirection == .ascending ? "✓ Date Modified (Oldest First)" : "Date Modified (Oldest First)") {
+              fileSystemSource.setSortOrder(.dateModified, direction: .ascending)
+            }
+            Button(fileSystemSource.sortOrder == .size && fileSystemSource.sortDirection == .descending ? "✓ Size (Largest First)" : "Size (Largest First)") {
+              fileSystemSource.setSortOrder(.size, direction: .descending)
+            }
+            Button(fileSystemSource.sortOrder == .size && fileSystemSource.sortDirection == .ascending ? "✓ Size (Smallest First)" : "Size (Smallest First)") {
+              fileSystemSource.setSortOrder(.size, direction: .ascending)
+            }
+            Button(fileSystemSource.sortOrder == .type && fileSystemSource.sortDirection == .ascending ? "✓ Type" : "Type") {
+              fileSystemSource.setSortOrder(.type, direction: .ascending)
+            }
+          }
+          
+          Divider()
+          
+          Button("Refresh") {
+            Task {
+              await fileSystemSource.refresh()
+            }
+          }
+          
+          Button("Reveal in Finder") {
+            NSWorkspace.shared.open(fileSystemSource.folderURL)
+          }
+          
+          Divider()
+          
+          Button("Close Tab", role: .destructive) {
+            onClose?()
+          }
+        } else if showCloseButton {
           Button(action: { onClose?() }) {
             Label("Close Tab", systemImage: "xmark")
           }

--- a/nozzle/Views/FolderTreeItemView.swift
+++ b/nozzle/Views/FolderTreeItemView.swift
@@ -85,11 +85,9 @@ struct FolderTreeItemView: View {
                         // Copy folder path when not selected
                         item.copyToClipboard()
                         appState.popup.close()
-                    } else if contentManager.canToggleExample(item.id) {
-                        // Toggle example state for textual-only folders
-                        contentManager.toggleExample(item.id)
                     } else {
-                        // Ignore toggle for non-textual folders
+                        // Toggle example state for folders
+                        contentManager.toggleExample(item.id)
                     }
                 } else {
                     // Focus and selection
@@ -107,6 +105,46 @@ struct FolderTreeItemView: View {
                     }
                 } else {
                     FolderTreeItemView.previewHoverThrottler.cancel()
+                }
+            }
+            .contextMenu {
+                if let url = item.base.fileURL {
+                    Button("Copy Path") {
+                        let pasteboard = NSPasteboard.general
+                        pasteboard.clearContents()
+                        pasteboard.setString(url.path, forType: .string)
+                    }
+                    
+                    Button("Open in Finder") {
+                        NSWorkspace.shared.open(url)
+                    }
+                    
+                    Divider()
+                    
+                    Button(isExpanded ? "Collapse" : "Expand") {
+                        toggleExpansion()
+                    }
+                    
+                    Divider()
+                    
+                    let folderSelectionState = contentManager.getFolderSelectionState(item.id)
+                    if folderSelectionState == .none {
+                        Button("Select All Contents") {
+                            contentManager.selectFolderChildren(item.id)
+                            appState.updateFooterItemVisibility()
+                        }
+                    } else {
+                        Button("Deselect All Contents") {
+                            contentManager.deselectFolderChildren(item.id)
+                            appState.updateFooterItemVisibility()
+                        }
+                    }
+                    
+                    Divider()
+                    
+                    Button("Remove from Sources", role: .destructive) {
+                        contentManager.removeSource(item.sourceId)
+                    }
                 }
             }
         }

--- a/nozzle/Views/HistoryItemView.swift
+++ b/nozzle/Views/HistoryItemView.swift
@@ -81,11 +81,9 @@ struct HistoryItemView: View {
         if !item.isSelected {
           // Copy button clicked - copy to clipboard
           copyItemToClipboard()
-        } else if contentManager.canToggleExample(item.id) {
-          // Toggle example state when clicking the selected checkmark area
-          contentManager.toggleExample(item.id)
         } else {
-          // Not textual; ignore toggle (keep selected as context)
+          // Toggle example state when clicking the selected checkmark area  
+          contentManager.toggleExample(item.id)
         }
       } else if NSEvent.modifierFlags.contains(.command) {
         // Command-click: immediate paste
@@ -95,6 +93,32 @@ struct HistoryItemView: View {
         contentManager.toggleSelection(item.id)
         item.isSelected = contentManager.isSelected(item.id)
         appState.selection = item.id  // Move focus to this item
+        appState.updateFooterItemVisibility()
+      }
+    }
+    .contextMenu {
+      Button("Copy") {
+        copyItemToClipboard()
+      }
+      
+      Button(item.isPinned ? "Unpin" : "Pin") {
+        appState.history.togglePin(item)
+      }
+      
+      Button("Delete") {
+        appState.highlightNext()
+        appState.history.delete(item)
+      }
+      
+      Divider()
+      
+      Button(contentManager.isExample(item.id) ? "Remove as Example" : "Mark as Example") {
+        contentManager.toggleExample(item.id)
+      }
+      
+      Button(contentManager.isSelected(item.id) ? "Remove as Context" : "Mark as Context") {
+        contentManager.toggleSelection(item.id)
+        item.isSelected = contentManager.isSelected(item.id)
         appState.updateFooterItemVisibility()
       }
     }

--- a/nozzle/Views/UniversalItemView.swift
+++ b/nozzle/Views/UniversalItemView.swift
@@ -53,11 +53,9 @@ struct UniversalItemView: View {
                                 item.copyToClipboard()
                                 // Optionally close the popup after copy
                                 appState.popup.close()
-                            } else if contentManager.canToggleExample(item.id) {
+                            } else {
                                 // Toggle example state when clicking the selected checkmark area
                                 contentManager.toggleExample(item.id)
-                            } else {
-                                // Not textual; ignore toggle
                             }
                         } else {
                             // Special handling for Prompts: add as chip instead of aggregated selection
@@ -101,6 +99,17 @@ struct UniversalItemView: View {
         }
         .contextMenu {
             if item.base.sourceId == "prompts", let url = item.base.fileURL {
+                Button("New") {
+                    (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt()
+                }
+                
+                Button("Add") {
+                    let currentText = appState.isSearchMode ? appState.history.searchQuery : appState.promptText
+                    (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt(initialContents: currentText)
+                }
+                
+                Divider()
+                
                 Button("Apply to input") {
                     (contentManager.sources["prompts"] as? PromptsSource)?.applyPrompt(at: url)
                     appState.addPromptChip(url: url)
@@ -118,6 +127,38 @@ struct UniversalItemView: View {
                 }
                 Button("Delete", role: .destructive) {
                     (contentManager.sources["prompts"] as? PromptsSource)?.deletePrompt(at: url)
+                }
+            } else if !item.base.isFolder, let url = item.base.fileURL {
+                // Context menu for regular files
+                Button("Copy") {
+                    item.copyToClipboard()
+                }
+                
+                Button("Copy Path") {
+                    let pasteboard = NSPasteboard.general
+                    pasteboard.clearContents()
+                    pasteboard.setString(url.path, forType: .string)
+                }
+                
+                Button("Open") {
+                    NSWorkspace.shared.open(url)
+                }
+                
+                Divider()
+                
+                Button(contentManager.isExample(item.id) ? "Remove as Example" : "Mark as Example") {
+                    contentManager.toggleExample(item.id)
+                }
+                
+                Button(contentManager.isSelected(item.id) ? "Remove as Context" : "Mark as Context") {
+                    contentManager.toggleSelection(item.id)
+                    appState.updateFooterItemVisibility()
+                }
+                
+                Divider()
+                
+                Button("Reveal in Finder") {
+                    NSWorkspace.shared.activateFileViewerSelecting([url])
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Adds context menus to all major content types (clipboard items, files, folders, prompts)
- Implements comprehensive sorting system for folder sources with 4 sort orders and 2 directions  
- Makes example marking independent - items can be marked as examples without requiring context selection
- Enhances folder tab menus with sorting, refresh, and reveal options
- Adds bulk operations to selected items view

## Test plan

- [ ] Test clipboard item context menu (Copy, Pin/Unpin, Delete, Mark as Example/Context)
- [ ] Test file item context menu (Copy, Copy Path, Open, Mark as Example/Context, Reveal in Finder)
- [ ] Test folder item context menu (Copy Path, Open, Expand/Collapse, Select/Deselect All, Remove Source)
- [ ] Test enhanced prompts menu (New, Add from input, Apply, Copy, Reveal, Duplicate, Delete)
- [ ] Test folder tab sorting (Name A-Z/Z-A, Date Modified, Size, Type with visual checkmarks)
- [ ] Test selected items view context menu (Copy All, Clear Selection, Convert All to Examples/Context)
- [ ] Verify example marking works independently of context selection
- [ ] Test sorting functionality refreshes content properly
- [ ] Verify all menus follow consistent interaction patterns

🤖 Generated with [Claude Code](https://claude.ai/code)