### PR TITLE
Keep prompt chips visible when switching to search mode

### DIFF
--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -16,9 +16,9 @@ struct ContentView: View {
     VStack(alignment: .leading, spacing: 0) {
       KeyHandlingView(searchQuery: $appState.history.searchQuery, searchFocused: $inputFocused) {
         VStack(spacing: 0) {
-          // Header: chips (prompt mode only), input field, and controls with tabs
+          // Header: chips (always show when present), input field, and controls with tabs
           VStack(spacing: 0) {
-            if !appState.isSearchMode {
+            if !appState.promptChips.isEmpty {
               PromptChipsBarView()
             }
 


### PR DESCRIPTION
## Summary
- Keep prompt chips visible during search/prompt mode switching to reduce UI distraction
- Maintain consistent positioning regardless of active mode

## Changes
- Modified `ContentView.swift` to show `PromptChipsBarView` based on chip presence rather than mode
- Changed condition from `\!appState.isSearchMode` to `\!appState.promptChips.isEmpty`

## Test plan
- [ ] Verify prompt chips remain visible when switching from prompt mode to search mode
- [ ] Verify prompt chips are hidden when no chips are present (regardless of mode)
- [ ] Verify chip interactions still work correctly in both modes
- [ ] Test mode switching behavior with and without prompt chips

🤖 Generated with [Claude Code](https://claude.ai/code)