### PR TITLE
Fix padding inconsistencies between search and prompt modes

### DIFF
--- a/nozzle/Views/UnifiedInputFieldView.swift
+++ b/nozzle/Views/UnifiedInputFieldView.swift
@@ -57,7 +57,7 @@ struct UnifiedInputFieldView: View {
   }
 
   var body: some View {
-    HStack(spacing: 6) {
+    HStack(spacing: 4) {
       // Search icon only in search mode, inline with text
       if isSearchMode {
         Image(systemName: "magnifyingglass")
@@ -89,6 +89,7 @@ struct UnifiedInputFieldView: View {
             Text(placeholderText)
               .font(.system(size: 13))
               .foregroundColor(.secondary.opacity(0.5))
+              .padding(.leading, 1)
               .allowsHitTesting(false)
           }
         }
@@ -126,13 +127,14 @@ struct UnifiedInputFieldView: View {
               Text(placeholderText)
                 .font(.system(size: 13))
                 .foregroundColor(.secondary.opacity(0.5))
-                .padding(.leading, 5)
+                .padding(.leading, 6)
                 .padding(.top, 0)
                 .allowsHitTesting(false)
             }
           }
         }
         .frame(height: textHeight)  // Apply height to GeometryReader
+        .padding(.bottom, -4)  // Reduce bottom padding to match search mode
       }
       
     }


### PR DESCRIPTION
## Summary
• Fixed UI shifting issue when switching between search and prompt modes in UnifiedInputFieldView
• Reduced spacing between magnifying glass and text field for tighter layout
• Prevented cursor bleeding into placeholder text with targeted padding adjustments

## Changes Made
- Reduced HStack spacing from 6 to 4 points between search icon and text field
- Added 1 point leading padding to search mode placeholder to prevent cursor overlap
- Adjusted prompt mode placeholder padding from 5 to 6 points for consistency
- Added -4 point bottom padding to prompt mode container to align field heights

## Test Plan
- [x] Switch between search and prompt modes - UI should no longer shift vertically
- [x] Verify magnifying glass spacing looks appropriate  
- [x] Confirm placeholder text doesn't overlap with blinking cursor in either mode
- [x] Test with both empty and filled text states

🤖 Generated with [Claude Code](https://claude.ai/code)