### PR TITLE
Improve list item alignment and spacing consistency

### DIFF
--- a/nozzle/Views/KeyboardShortcutView.swift
+++ b/nozzle/Views/KeyboardShortcutView.swift
@@ -16,9 +16,9 @@ struct KeyboardShortcutView: View {
   }
 
   var body: some View {
-    HStack(spacing: 1) {
-      Text(modifiers).frame(width: 55, alignment: .trailing)
-      Text(character).frame(width: 12, alignment: .center)
+    HStack(spacing: 0) {
+      Text(modifiers).frame(width: 45, alignment: .trailing)
+      Text(character).frame(width: 10, alignment: .center)
     }
     .lineLimit(1)
     .opacity(character.isEmpty ? 0 : 0.4)

--- a/nozzle/Views/ListItemView.swift
+++ b/nozzle/Views/ListItemView.swift
@@ -56,12 +56,12 @@ struct ListItemView<Title: View>: View {
             .frame(width: 15, height: 15)
           Spacer(minLength: 0)
         }
-        .padding(.leading, 4)
+        .padding(.leading, 6)
         .padding(.vertical, 5)
       }
 
       Spacer()
-        .frame(width: (showIcons && appIcon != nil) ? 5 : 10)
+        .frame(width: (showIcons && appIcon != nil) ? 6 : 12)
 
       if let accessoryImage {
         Image(nsImage: accessoryImage)
@@ -87,11 +87,13 @@ struct ListItemView<Title: View>: View {
       if showCheckbox {
         ZStack {
           if modifierFlags.flags.contains(.command) && !shortcuts.isEmpty {
-            // Show shortcut when Command is held
+            // Show shortcut when Command is held (replaces checkmark)
             ForEach(shortcuts) { shortcut in
               KeyboardShortcutView(shortcut: shortcut)
                 .opacity(shortcut.isVisible(shortcuts, modifierFlags.flags) ? 1 : 0)
             }
+            .padding(.trailing, 20)
+            .frame(maxWidth: .infinity, alignment: .trailing)
           } else if isSelected {
             // Show round checkbox when item is selected
             Image(systemName: selectionSymbol)
@@ -108,8 +110,8 @@ struct ListItemView<Title: View>: View {
               .frame(maxWidth: .infinity, alignment: .trailing)
           }
         }
-        .frame(width: 32)
-        .padding(.trailing, 10)
+        .frame(width: 30)
+        .padding(.trailing, 8)
       } else if !shortcuts.isEmpty {
         // For footer items, just show shortcuts
         ZStack {
@@ -118,12 +120,12 @@ struct ListItemView<Title: View>: View {
               .opacity(shortcut.isVisible(shortcuts, modifierFlags.flags) ? 1 : 0)
           }
         }
-        .frame(width: 32)
-        .padding(.trailing, 10)
+        .frame(width: 30)
+        .padding(.trailing, 8)
       } else {
         Spacer()
-          .frame(width: 32)
-          .padding(.trailing, 10)
+          .frame(width: 30)
+          .padding(.trailing, 8)
       }
     }
     .frame(minHeight: 22)
@@ -147,6 +149,8 @@ struct ListItemView<Title: View>: View {
       }
     }
     .clipShape(.rect(cornerRadius: DesignConstants.cornerRadius))
+    .padding(.leading, 3)
+    .padding(.trailing, 5)
     // Any mouse movement exits keyboard navigation mode
     .onMouseMove {
       appState.isKeyboardNavigating = false


### PR DESCRIPTION
## Summary
- Fix hover background symmetry with asymmetrical padding for better visual balance
- Shift list content right to align with header UI elements  
- Tighten command shortcut display by removing spacing between ⌘ and numbers
- Position command shortcuts to properly replace checkmarks when holding Command
- Adjust right-side element spacing for improved consistency

## Test plan
- [x] Hover backgrounds have symmetrical appearance with proper margins
- [x] List content (icons + text) aligns better with header spacing
- [x] Command shortcuts appear tightly formatted (⌘1, ⌘2, etc.)  
- [x] Shortcuts replace checkmarks in exact position when holding Command
- [x] Overall visual consistency improved across all list item states

🤖 Generated with [Claude Code](https://claude.ai/code)