### PR TITLE
Add smooth fade animation to footer icons when switching modes

### DIFF
--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -167,6 +167,7 @@ struct ContentView: View {
                     appState.isSearchMode ? .secondary : (contentManager.activeSourceId == "prompts" ? Color(NSColor.controlAccentColor) : .secondary)
                   )
                   .opacity(appState.isSearchMode ? 0.5 : 0.9)
+                  .animation(.easeInOut(duration: 0.2), value: appState.isSearchMode)
               }
               .buttonStyle(PlainButtonStyle())
               .help(appState.isSearchMode ? "Exit search mode" : "Open Prompts")
@@ -190,6 +191,7 @@ struct ContentView: View {
                   .font(.system(size: 15))
                   .foregroundColor(dictationManager.isRecording ? .orange : .secondary)
                   .opacity(appState.isSearchMode ? 0.5 : (dictationManager.isRecording ? 1.0 : 0.8))
+                  .animation(.easeInOut(duration: 0.2), value: appState.isSearchMode)
                   .padding(.all, 2)
               }
               .buttonStyle(PlainButtonStyle())
@@ -213,6 +215,7 @@ struct ContentView: View {
                   .font(.system(size: 15))
                   .foregroundColor(.secondary)
                   .opacity(appState.isSearchMode ? 0.5 : 0.8)
+                  .animation(.easeInOut(duration: 0.2), value: appState.isSearchMode)
                   .padding(.all, 2)
               }
               .buttonStyle(PlainButtonStyle())


### PR DESCRIPTION
## Summary
- Add smooth fade animations to the three footer icons (plus, mic, enhance buttons) when switching between search and prompt modes
- Replace abrupt opacity changes with easeInOut animations (0.2s duration) 
- Creates a more polished and less jarring user experience

## Test plan
- [x] Build the project successfully to verify syntax
- [ ] Test switching between search mode (Cmd+F) and prompt mode to see smooth icon fading
- [ ] Verify animations feel natural and not too fast/slow
- [ ] Ensure icons still function correctly during animations

🤖 Generated with [Claude Code](https://claude.ai/code)