### PR TITLE
Add app icon support for clipboard items in aggregated view

### DIFF
--- a/nozzle/Models/ContentItem.swift
+++ b/nozzle/Models/ContentItem.swift
@@ -28,6 +28,9 @@ public struct ContentItem: Identifiable, Hashable, Sendable {
     public let depth: Int
     public let parentPath: String?
     
+    // App icon support for clipboard items
+    public let applicationBundleId: String?
+    
     // UI state (kept here so Universal views don't mutate external state)
     public var isSelected: Bool = false
     public var isVisible: Bool = true
@@ -49,6 +52,7 @@ public struct ContentItem: Identifiable, Hashable, Sendable {
         isFolder: Bool = false,
         depth: Int = 0,
         parentPath: String? = nil,
+        applicationBundleId: String? = nil,
         isSelected: Bool = false,
         isVisible: Bool = true
     ) {
@@ -68,6 +72,7 @@ public struct ContentItem: Identifiable, Hashable, Sendable {
         self.isFolder = isFolder
         self.depth = depth
         self.parentPath = parentPath
+        self.applicationBundleId = applicationBundleId
         self.isSelected = isSelected
         self.isVisible = isVisible
     }

--- a/nozzle/Observables/ClipboardSource.swift
+++ b/nozzle/Observables/ClipboardSource.swift
@@ -29,6 +29,7 @@ final class ClipboardSource: ContentSource {
                 rtfData: decorator.item.rtfData,
                 htmlData: decorator.item.htmlData,
                 plainText: decorator.item.text,
+                applicationBundleId: decorator.item.application,
                 isSelected: decorator.isSelected,
                 isVisible: decorator.isVisible
             )

--- a/nozzle/Observables/UniversalItemDecorator.swift
+++ b/nozzle/Observables/UniversalItemDecorator.swift
@@ -12,6 +12,9 @@ final class UniversalItemDecorator: ListItemDecorator {
     // Cached thumbnail for performance
     private var _thumbnailImage: NSImage?
     
+    // App icon for clipboard items
+    private var _appIcon: ApplicationImage?
+    
     // Static thumbnail size to match HistoryItemDecorator
     static var thumbnailImageSize: NSSize { 
         NSSize(width: 340, height: Defaults[.imageMaxHeight]) 
@@ -42,8 +45,30 @@ final class UniversalItemDecorator: ListItemDecorator {
         return ApplicationImage(bundleIdentifier: nil, image: nsImage)
     }
     
+    // App icon for clipboard items
+    var clipboardAppIcon: ApplicationImage? {
+        if _appIcon == nil, base.sourceType == .clipboard, let bundleId = base.applicationBundleId {
+            Task {
+                let appIcon = await ApplicationImageCache.shared.getImage(
+                    universalClipboard: false, 
+                    application: bundleId
+                )
+                await MainActor.run {
+                    _appIcon = appIcon
+                }
+            }
+        }
+        return _appIcon
+    }
+    
     // Protocol conformance - ListItemDecorator
-    var appIcon: ApplicationImage? { typeBadgeImage }
+    var appIcon: ApplicationImage? { 
+        // For clipboard items, prefer app icon over file type badge
+        if base.sourceType == .clipboard {
+            return clipboardAppIcon ?? typeBadgeImage
+        }
+        return typeBadgeImage
+    }
     var image: NSImage? { 
         if _thumbnailImage == nil, 
            let imageData = base.imageData,
@@ -62,6 +87,19 @@ final class UniversalItemDecorator: ListItemDecorator {
         self.base = item
         self.sourceId = item.sourceId
         self.isVisible = item.isVisible
+        
+        // Initialize app icon for clipboard items
+        if item.sourceType == .clipboard, let bundleId = item.applicationBundleId {
+            Task {
+                let appIcon = await ApplicationImageCache.shared.getImage(
+                    universalClipboard: false, 
+                    application: bundleId
+                )
+                await MainActor.run {
+                    self._appIcon = appIcon
+                }
+            }
+        }
     }
     
     nonisolated func hash(into hasher: inout Hasher) {

--- a/nozzle/Views/UniversalItemView.swift
+++ b/nozzle/Views/UniversalItemView.swift
@@ -28,7 +28,7 @@ struct UniversalItemView: View {
                     
                     ListItemView(
                         id: item.id,
-                        appIcon: (item.base.sourceId == "prompts" ? nil : item.typeBadgeImage),        // Hide file type badge for Prompts
+                        appIcon: (item.base.sourceId == "prompts" ? nil : item.appIcon),        // Show app icons for all sources except Prompts
                         image: item.image,
                         accessoryImage: nil,
                         attributedTitle: nil,


### PR DESCRIPTION
## Summary
• Adds app icon display support for clipboard items in the aggregated "#" selected items view
• Shows originating app icons (Safari, Chrome, VS Code, etc.) instead of generic file type badges for clipboard content
• Provides visual consistency between the main clipboard view and cross-source selections

## Changes Made
• **ContentItem Model**: Added `applicationBundleId` property to store app bundle identifiers
• **ClipboardSource**: Updated to include app bundle ID when mapping clipboard items to ContentItem
• **UniversalItemDecorator**: Enhanced to load and cache app icons using existing ApplicationImageCache infrastructure
• **UniversalItemView**: Modified to prefer app icons over file type badges for clipboard items

## Behavior
• **Clipboard items**: Show app icons (with fallback to file type badges if unavailable)
• **File items**: Continue showing file type badges as before  
• **Prompts**: No icons shown as before

## Test plan
- [x] Build succeeds without errors
- [x] Existing file type badge behavior preserved for file items
- [x] App icon loading uses existing async infrastructure
- [x] Maintains backward compatibility with all existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)