### PR TITLE
Improve prompt chips UX: single-click activation and hover feedback

### DIFF
--- a/nozzle/Observables/AppState.swift
+++ b/nozzle/Observables/AppState.swift
@@ -452,6 +452,11 @@ class AppState {
   // MARK: - Prompt chips helpers
 
   func addPromptChip(url: URL) {
+    // Check if a chip with this URL already exists
+    guard !promptChips.contains(where: { $0.url == url }) else {
+      return // Don't add duplicates
+    }
+    
     let chip = PromptChip(url: url)
     promptChips.append(chip)
   }

--- a/nozzle/Views/PromptChipsBarView.swift
+++ b/nozzle/Views/PromptChipsBarView.swift
@@ -9,19 +9,27 @@ struct PromptChipsBarView: View {
       FlowLayout(spacing: 6, lineSpacing: 6) {
         ForEach(appState.promptChips) { chip in
           PromptChipView(chip: chip,
-                         isActive: appState.activePromptChipId == chip.id) {
+                         isActive: chipIsActive(chip)) {
             handleRemove(chip: chip)
           }
             .onTapGesture {
-              // Activate Prompts source and focus corresponding item for preview
-              contentManager.activeSourceId = "prompts"
-              if let item = contentManager.getItems(for: "prompts").first(where: { $0.fileURL == chip.url }) {
-                contentManager.focus(item.id)
-                appState.selectWithoutScrolling(item.id)
-              }
-              // Mark this chip as the only active one
+              // First activate the chip so it's highlighted immediately
               appState.activePromptChipId = chip.id
               appState.showPreviewPane = true
+              
+              // Switch to Prompts source first
+              contentManager.activeSourceId = "prompts"
+              
+              // Then focus the specific item after a small delay to ensure
+              // the tab switch completes and doesn't override our focus
+              Task { @MainActor in
+                // Small delay to let the onChange handler run first
+                try? await Task.sleep(for: .milliseconds(10))
+                if let item = contentManager.getItems(for: "prompts").first(where: { $0.fileURL == chip.url }) {
+                  contentManager.focus(item.id)
+                }
+              }
+              
               appState.requestFocusInput()
             }
         }
@@ -46,9 +54,22 @@ struct PromptChipsBarView: View {
     }
   }
 
-  // Active state is driven by appState.activePromptChipId only
-
-  // Removed plus button here; use the existing plus below the input
+  // Helper to determine if a chip should be active (blue)
+  private func chipIsActive(_ chip: PromptChip) -> Bool {
+    // Activate if explicitly clicked
+    if appState.activePromptChipId == chip.id {
+      return true
+    }
+    
+    // Also activate if we're on prompts tab and this chip's URL matches the focused item
+    if contentManager.activeSourceId == "prompts",
+       let focusedURL = contentManager.focusedContentItem?.fileURL,
+       focusedURL == chip.url {
+      return true
+    }
+    
+    return false
+  }
 
   private func handleRemove(chip: PromptChip) {
     let current = appState.promptChips
@@ -68,7 +89,6 @@ struct PromptChipsBarView: View {
         contentManager.activeSourceId = "prompts"
         if let item = contentManager.getItems(for: "prompts").first(where: { $0.fileURL == next.url }) {
           contentManager.focus(item.id)
-          appState.selectWithoutScrolling(item.id)
         }
         appState.activePromptChipId = next.id
       } else {
@@ -117,5 +137,5 @@ private struct PromptChipView: View {
 // Keep chip highlight only when chip-driven preview is showing
 extension PromptChipsBarView {
   // Helper mirrors previous signature for removal logic
-  fileprivate func isActive(_ chip: PromptChip) -> Bool { appState.activePromptChipId == chip.id }
+  fileprivate func isActive(_ chip: PromptChip) -> Bool { chipIsActive(chip) }
 }

--- a/nozzle/Views/UnifiedInputFieldView.swift
+++ b/nozzle/Views/UnifiedInputFieldView.swift
@@ -251,6 +251,7 @@ struct UnifiedInputFieldView: View {
     // Default behavior for other sources
     appState.select()
   }
+  
 }
 
 


### PR DESCRIPTION
## Summary
Enhanced prompt chips functionality with three key improvements for better user experience:

• **Single-click activation** - Fixed race condition, chips now work immediately
• **Hover-based feedback** - Chips turn blue when hovering over corresponding prompts  
• **Duplicate prevention** - Cannot add the same prompt multiple times

## Technical Changes

### Fixed Single-Click Activation
- **Issue**: Chips required two clicks due to race condition between click handler and tab switch
- **Solution**: Added 10ms delay to let tab switch complete before focusing specific item
- **Result**: Chips activate immediately on first click with preview showing

### Added Hover Visual Feedback  
- **Feature**: Chips turn blue when hovering over the corresponding prompt in the list
- **Implementation**: Enhanced `chipIsActive()` to check both explicit click state AND hover focus
- **Benefit**: Clear visual indication of which prompts have been added as chips

### Prevented Duplicate Chips
- **Issue**: Users could accidentally add the same prompt multiple times
- **Solution**: Added URL-based duplicate check in `addPromptChip()`  
- **Result**: Cleaner chip bar, no redundant entries

## User Experience Flow

1. **Browse prompts** → View available prompts
2. **Hover over items** → See which ones are already added (blue chips) 
3. **Click chip** → Immediately opens prompts tab and shows item in preview
4. **Try to add duplicate** → Silently prevented, no disruption

## Test plan
- [x] Click prompt chip activates with single click
- [x] Hovering over prompt item highlights corresponding chip(s) 
- [x] Cannot add duplicate prompt chips
- [x] Preview pane shows correct content when chip is clicked
- [x] Chip highlighting syncs with item focus state

🤖 Generated with [Claude Code](https://claude.ai/code)