### PR TITLE
Add Shift+Enter support for newlines in prompt mode

### DIFF
--- a/nozzle/Views/KeyHandlingView.swift
+++ b/nozzle/Views/KeyHandlingView.swift
@@ -48,6 +48,11 @@ struct KeyHandlingView<Content: View>: View {
               appState.performCombinedPaste()
               return .handled
             }
+          } else if modifierFlags == .shift {
+            // Shift+Enter in prompt mode - let TextEditor handle naturally for newlines
+            if !appState.isSearchMode {
+              return .ignored  // Let TextEditor handle the newline
+            }
           }
         }
         

--- a/nozzle/Views/UnifiedInputFieldView.swift
+++ b/nozzle/Views/UnifiedInputFieldView.swift
@@ -63,11 +63,7 @@ struct UnifiedInputFieldView: View {
     _ = layoutManager.glyphRange(for: container)
     var measured = ceil(layoutManager.usedRect(for: container).height)
 
-    // Account for trailing newline which AppKit can treat as zero-width at end
-    if text.hasSuffix("\n") {
-      let lineHeight = ceil(layoutManager.defaultLineHeight(for: font))
-      measured += lineHeight
-    }
+    // Removed problematic trailing newline handling that was causing double newlines
 
     // Enforce min and max heights
     if measured < baseHeight { measured = baseHeight }
@@ -151,9 +147,14 @@ struct UnifiedInputFieldView: View {
                   fieldWidth = newWidth
                   textHeight = calculateTextHeight(query, width: newWidth - 20) // Account for clear button space
                 }
-                .onSubmit {
-                  if !query.contains("\n") {
+                .onKeyPress(keys: [.return]) { keyPress in
+                  if keyPress.modifiers.contains(.shift) {
+                    // Let TextEditor handle Shift+Enter naturally (creates newline)
+                    return .ignored
+                  } else {
+                    // Plain Enter - submit
                     handleSubmit()
+                    return .handled
                   }
                 }
                 .onAppear {


### PR DESCRIPTION
## Summary
- Adds native Shift+Enter support for creating new lines in the prompt mode text editor
- Fixes the "double newline then self-corrects" issue that was occurring with the height calculation
- Maintains existing Enter to submit behavior

## Changes Made
### KeyHandlingView.swift
- Added Shift+Enter passthrough logic for prompt mode to allow TextEditor to handle newlines naturally
- Only applies in prompt mode (`!appState.isSearchMode`) to maintain search mode behavior

### UnifiedInputFieldView.swift  
- Replaced `.onSubmit` with `.onKeyPress(keys: [.return])` to properly distinguish between Shift+Enter and plain Enter
- Removed problematic trailing newline height calculation that was double-counting newlines and causing visual glitches
- Maintains precise TextKit-based height measurement without the double-counting issue

## Behavior
- **Shift+Enter in prompt mode**: Creates a new line naturally ✅
- **Enter in prompt mode**: Submits the prompt ✅  
- **Search mode**: Unchanged behavior ✅
- **Height calculation**: No more double newlines or visual glitches ✅

## Technical Details
The issue was that KeyHandlingView was intercepting all Return key events before they could reach the TextEditor. The solution uses a two-layer approach:
1. KeyHandlingView allows Shift+Enter to pass through in prompt mode
2. TextEditor's onKeyPress handler lets Shift+Enter be handled naturally by TextEditor while plain Enter triggers submit

🤖 Generated with [Claude Code](https://claude.ai/code)