### PR TITLE
Add visual and audio feedback for clipboard icon copy action

### DIFF
--- a/nozzle/Views/HistoryItemView.swift
+++ b/nozzle/Views/HistoryItemView.swift
@@ -52,7 +52,8 @@ struct HistoryItemView: View {
       isSelected: item.isSelected,
       selectionSymbol: (contentManager.isExample(item.id) ? "pencil.circle" : "checkmark.circle.fill"),
       selectionSymbolColor: (contentManager.isExample(item.id) ? .yellow : .white),
-      selectionBackgroundColor: (contentManager.isExample(item.id) ? .yellow : nil)
+      selectionBackgroundColor: (contentManager.isExample(item.id) ? .yellow : nil),
+      onCopyAction: copyItemToClipboard
     ) {
       Text(verbatim: item.title)
     }
@@ -72,19 +73,14 @@ struct HistoryItemView: View {
       appState.isKeyboardNavigating = false
     }
     .onTapGesture { location in
-      // Check if click is in the copy button area (right 60 pixels)
+      // Check if click is in the checkbox/selection area (right 60 pixels)
       let frameWidth = copyButtonArea.width > 0 ? copyButtonArea.width : 300 // fallback width
-      let copyButtonAreaWidth: CGFloat = 42
-      let isCopyButtonClick = location.x > (frameWidth - copyButtonAreaWidth)
+      let selectionAreaWidth: CGFloat = 42
+      let isSelectionAreaClick = location.x > (frameWidth - selectionAreaWidth)
       
-      if isCopyButtonClick {
-        if !item.isSelected {
-          // Copy button clicked - copy to clipboard
-          copyItemToClipboard()
-        } else {
-          // Toggle example state when clicking the selected checkmark area  
-          contentManager.toggleExample(item.id)
-        }
+      if isSelectionAreaClick && item.isSelected {
+        // Toggle example state when clicking the selected checkmark area
+        contentManager.toggleExample(item.id)
       } else if NSEvent.modifierFlags.contains(.command) {
         // Command-click: immediate paste
         appState.history.select(item)

--- a/nozzle/Views/ListItemView.swift
+++ b/nozzle/Views/ListItemView.swift
@@ -20,6 +20,7 @@ struct ListItemView<Title: View>: View {
   var selectionSymbol: String = "checkmark.circle.fill"
   var selectionSymbolColor: Color = .white
   var selectionBackgroundColor: Color? = nil
+  var onCopyAction: (() -> Void)? = nil
   @ViewBuilder var title: () -> Title
 
   @Default(.showApplicationIcons) private var showIcons
@@ -27,6 +28,26 @@ struct ListItemView<Title: View>: View {
   @Environment(ContentManager.self) private var contentManager
   @Environment(ModifierFlags.self) private var modifierFlags
   @State private var isHovering = false
+  @State private var showCopiedFeedback = false
+  
+  private func triggerCopyFeedback() {
+    // Visual feedback
+    withAnimation(.easeInOut(duration: 0.2)) {
+      showCopiedFeedback = true
+    }
+    
+    // Audio feedback
+    if let sound = NSSound(named: "Write") {
+      sound.play()
+    }
+    
+    // Reset after delay
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+      withAnimation(.easeInOut(duration: 0.3)) {
+        showCopiedFeedback = false
+      }
+    }
+  }
   
   private var shouldShowHoverBackground: Bool {
     // Immediate hover background only when not keyboard navigating
@@ -102,12 +123,26 @@ struct ListItemView<Title: View>: View {
               .opacity(0.8)
               .frame(maxWidth: .infinity, alignment: .trailing)
           } else if isHovering {
-            // Show copy button when hovering - always show the clipboard icon
-            Image(systemName: "doc.on.doc")
-              .font(.system(size: 12))
-              .foregroundColor(.primary)
-              .opacity(0.6)
-              .frame(maxWidth: .infinity, alignment: .trailing)
+            // Show copy button when hovering, or checkmark when copied
+            if showCopiedFeedback {
+              Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 12))
+                .foregroundColor(.green)
+                .opacity(0.8)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .transition(.scale.combined(with: .opacity))
+            } else {
+              Image(systemName: "doc.on.doc")
+                .font(.system(size: 12))
+                .foregroundColor(.primary)
+                .opacity(0.6)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .transition(.scale.combined(with: .opacity))
+                .onTapGesture {
+                  onCopyAction?()
+                  triggerCopyFeedback()
+                }
+            }
           }
         }
         .frame(width: 30)

--- a/nozzle/Views/UniversalItemView.swift
+++ b/nozzle/Views/UniversalItemView.swift
@@ -36,27 +36,21 @@ struct UniversalItemView: View {
                         isSelected: item.isSelected,
                         selectionSymbol: (item.isExample ? "pencil.circle" : "checkmark.circle.fill"),
                         selectionSymbolColor: (item.isExample ? .yellow : .white),
-                        selectionBackgroundColor: (item.isExample ? .yellow : nil)
+                        selectionBackgroundColor: (item.isExample ? .yellow : nil),
+                        onCopyAction: { item.copyToClipboard() }
                     ) {
                         Text(verbatim: item.title)
                             .lineLimit(1)
                             .truncationMode(.middle)
                     }
                     .onTapGesture { location in
-                        // Emulate HistoryItemView behavior: right area = copy; else toggle selection
-                        let copyAreaThreshold: CGFloat = 42
+                        // Check if click is in the checkbox/selection area (right 60 pixels)
+                        let selectionAreaThreshold: CGFloat = 42
                         let frameWidth: CGFloat = 300  // Approximate width
                         
-                        if location.x > (frameWidth - copyAreaThreshold) {
-                            if !item.isSelected {
-                                // Copy action
-                                item.copyToClipboard()
-                                // Optionally close the popup after copy
-                                appState.popup.close()
-                            } else {
-                                // Toggle example state when clicking the selected checkmark area
-                                contentManager.toggleExample(item.id)
-                            }
+                        if location.x > (frameWidth - selectionAreaThreshold) && item.isSelected {
+                            // Toggle example state when clicking the selected checkmark area
+                            contentManager.toggleExample(item.id)
                         } else {
                             // Special handling for Prompts: add as chip instead of aggregated selection
                             if item.base.sourceId == "prompts",


### PR DESCRIPTION
## Summary
- Add immediate visual feedback when clipboard icon is clicked - icon transforms to green checkmark with smooth animation
- Add audio feedback using existing Write.caf sound file
- Centralize copy feedback logic in ListItemView for consistency across all content sources

## Test plan
- [ ] Hover over any clipboard history item to see clipboard icon
- [ ] Click the clipboard icon and verify it transforms to green checkmark
- [ ] Verify audio plays when copy succeeds  
- [ ] Test with both clipboard history items and file system items
- [ ] Verify feedback works consistently across all content sources
- [ ] Confirm existing click behavior for selection/example toggle still works

🤖 Generated with [Claude Code](https://claude.ai/code)