### PR TITLE
Remove text labels from preview pane no-selection view

### DIFF
--- a/nozzle/Views/Preview/PreviewPaneView.swift
+++ b/nozzle/Views/Preview/PreviewPaneView.swift
@@ -92,12 +92,6 @@ struct NoSelectionView: View {
             Image(systemName: "doc.text.magnifyingglass")
                 .font(.system(size: 48))
                 .foregroundColor(.secondary.opacity(0.5))
-            Text("No item selected")
-                .font(.headline)
-                .foregroundColor(.secondary)
-            Text("Select an item to preview")
-                .font(.caption)
-                .foregroundColor(.secondary.opacity(0.8))
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary
• Simplify the NoSelectionView by removing text labels
• Keep only the magnifying glass icon for a cleaner appearance
• Improves visual consistency and reduces visual clutter in the preview pane

## Test plan
- [ ] Verify that when no item is selected, only the icon shows (no text)
- [ ] Ensure the icon is properly centered in the preview pane
- [ ] Test across different window sizes and themes

🤖 Generated with [Claude Code](https://claude.ai/code)