### PR TITLE
Refine prompt chip labeling in combined paste output

### DIFF
--- a/nozzle/Utilities/CombinedContentBuilder.swift
+++ b/nozzle/Utilities/CombinedContentBuilder.swift
@@ -30,10 +30,10 @@ enum CombinedContentBuilder {
         }
 
         if !chips.isEmpty {
-            for (index, chip) in chips.enumerated() {
-                pieces.append(.string("<prompt \(index + 1)>\n"))
+            for chip in chips {
+                pieces.append(.string("<prompt>\n"))
                 pieces.append(.chip(chip.url))
-                pieces.append(.string("\n"))
+                pieces.append(.string("\n</prompt>\n"))
             }
         }
 


### PR DESCRIPTION
## Summary
• Remove numbering from prompt chips in combined paste output
• Wrap prompt chips in consistent XML-style `<prompt>` tags to match context and example item labeling

## Test plan
- [x] Verify prompt chips are wrapped in `<prompt>` tags without numbering
- [x] Ensure consistency with existing `<context>` and `<example>` tag patterns
- [ ] Test combined paste output with multiple prompt chips

🤖 Generated with [Claude Code](https://claude.ai/code)