### PR TITLE
Update example icon to use filled variant for consistent styling

### DIFF
--- a/nozzle/Views/FolderTreeItemView.swift
+++ b/nozzle/Views/FolderTreeItemView.swift
@@ -26,7 +26,7 @@ struct FolderTreeItemView: View {
     private var selectionState: (isSelected: Bool, symbol: String) {
         // If marked as example, override UI to reflect example state
         if contentManager.isExample(item.id) {
-            return (true, "pencil.circle")
+            return (true, "pencil.circle.fill")
         }
         let folderSelectionState = contentManager.getFolderSelectionState(item.id)
         switch folderSelectionState {

--- a/nozzle/Views/HistoryItemView.swift
+++ b/nozzle/Views/HistoryItemView.swift
@@ -50,7 +50,7 @@ struct HistoryItemView: View {
       attributedTitle: item.attributedTitle,
       shortcuts: item.shortcuts,
       isSelected: item.isSelected,
-      selectionSymbol: (contentManager.isExample(item.id) ? "pencil.circle" : "checkmark.circle.fill"),
+      selectionSymbol: (contentManager.isExample(item.id) ? "pencil.circle.fill" : "checkmark.circle.fill"),
       selectionSymbolColor: (contentManager.isExample(item.id) ? .yellow : .white),
       selectionBackgroundColor: (contentManager.isExample(item.id) ? .yellow : nil),
       onCopyAction: copyItemToClipboard

--- a/nozzle/Views/UniversalItemView.swift
+++ b/nozzle/Views/UniversalItemView.swift
@@ -34,7 +34,7 @@ struct UniversalItemView: View {
                         attributedTitle: nil,
                         shortcuts: [],                       // no numbered shortcuts for file sources in Phase 1
                         isSelected: item.isSelected,
-                        selectionSymbol: (item.isExample ? "pencil.circle" : "checkmark.circle.fill"),
+                        selectionSymbol: (item.isExample ? "pencil.circle.fill" : "checkmark.circle.fill"),
                         selectionSymbolColor: (item.isExample ? .yellow : .white),
                         selectionBackgroundColor: (item.isExample ? .yellow : nil),
                         onCopyAction: { item.copyToClipboard() }


### PR DESCRIPTION
## Summary
- Update example items to use `pencil.circle.fill` instead of `pencil.circle`
- Provides consistent white backdrop styling with context icons (`checkmark.circle.fill`)
- Preserves yellow color scheme for example items

## Test plan
- [ ] Build and run the app
- [ ] Mark items as examples and verify the pencil icon has proper white backdrop
- [ ] Verify context icons still display correctly with checkmark
- [ ] Test across different content sources (clipboard, files)

🤖 Generated with [Claude Code](https://claude.ai/code)