### PR TITLE
Remove slash commands and improve prompts UX with right-click menus

### DIFF
--- a/nozzle/Observables/PromptsSource.swift
+++ b/nozzle/Observables/PromptsSource.swift
@@ -25,9 +25,9 @@ final class PromptsSource: ContentSource {
         self.inner = FileSystemSource(folderURL: folderURL)
     }
 
-    // Only show prompt-like files. Inject slash-commands when user typed "/".
+    // Only show prompt-like files.
     var items: [ContentItem] {
-        var base = inner.items
+        return inner.items
             .filter { !$0.isFolder }
             .filter { $0.isText || $0.isMarkdown || $0.uniformTypeIdentifier == UTType.plainText.identifier }
             .map { item in
@@ -53,12 +53,6 @@ final class PromptsSource: ContentSource {
                     isVisible: item.isVisible
                 )
             }
-
-        if searchQuery.hasPrefix("/") {
-            base.insert(commandItem(title: "/new – New empty prompt", command: .new), at: 0)
-            base.insert(commandItem(title: "/add – Save current input as new prompt", command: .add), at: 0)
-        }
-        return base
     }
 
     func startMonitoring() { inner.startMonitoring() }
@@ -66,7 +60,7 @@ final class PromptsSource: ContentSource {
     func refresh() async { await inner.refresh() }
 
     func search(query: String) -> [ContentItem] {
-        // Mirror filtering and slash commands
+        // Filter items based on title and content
         let filtered = items.filter {
             $0.title.localizedCaseInsensitiveContains(query) ||
             ($0.plainText ?? "").localizedCaseInsensitiveContains(query)
@@ -74,30 +68,7 @@ final class PromptsSource: ContentSource {
         return filtered
     }
 
-    // MARK: - Commands & helpers
-
-    private enum Command { case add, new }
-
-    private func commandItem(title: String, command: Command) -> ContentItem {
-        ContentItem(
-            id: UUID(),
-            title: title,
-            timestamp: Date(),
-            sourceType: .folder,
-            sourceId: id,
-            fileURL: nil,
-            imageData: nil,
-            rtfData: nil,
-            htmlData: nil,
-            plainText: nil,
-            fileIdentity: nil,
-            uniformTypeIdentifier: "org.nozzle.command.\(command == .add ? "add" : "new")",
-            fileSize: nil,
-            isFolder: false,
-            depth: 0,
-            parentPath: nil
-        )
-    }
+    // MARK: - Helpers
 
     static func defaultFolder() -> URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!

--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -171,6 +171,30 @@ struct ContentView: View {
               }
               .buttonStyle(PlainButtonStyle())
               .help(appState.isSearchMode ? "Exit search mode" : "Open Prompts")
+              .contextMenu {
+                if !appState.isSearchMode {
+                  Button("New") {
+                    (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt()
+                  }
+                  
+                  Button("Add") {
+                    let currentText = appState.promptText
+                    if !currentText.isEmpty {
+                      (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt(initialContents: currentText)
+                    }
+                  }
+                  
+                  Divider()
+                  
+                  Button("Open Prompts") {
+                    if contentManager.activeSourceId != "prompts" {
+                      contentManager.lastNonPromptsSourceId = contentManager.activeSourceId
+                      selectedTab = "prompts"
+                      contentManager.activeSourceId = "prompts"
+                    }
+                  }
+                }
+              }
               
               // Microphone button
               Button(action: {
@@ -407,8 +431,53 @@ struct ContentView: View {
               // Non-clipboard sources use unified ListView
               let items = contentManager.getItems(for: contentManager.activeSourceId)
                 .map(UniversalItemDecorator.init)
-              ListView(universalItems: items)
-                .frame(minWidth: 300)
+              
+              if contentManager.activeSourceId == "prompts" {
+                // Add context menu for prompts view with empty state
+                if items.isEmpty {
+                  VStack {
+                    Spacer()
+                    Text("No prompts found")
+                      .font(.system(size: 14))
+                      .foregroundColor(.secondary)
+                    Text("Right-click to create your first prompt")
+                      .font(.system(size: 12))
+                      .foregroundColor(Color.secondary.opacity(0.7))
+                    Spacer()
+                  }
+                  .frame(minWidth: 300, maxWidth: .infinity)
+                  .contextMenu {
+                    Button("New") {
+                      (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt()
+                    }
+                    
+                    Button("Add") {
+                      let currentText = appState.isSearchMode ? appState.history.searchQuery : appState.promptText
+                      if !currentText.isEmpty {
+                        (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt(initialContents: currentText)
+                      }
+                    }
+                  }
+                } else {
+                  ListView(universalItems: items)
+                    .frame(minWidth: 300)
+                    .contextMenu {
+                      Button("New") {
+                        (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt()
+                      }
+                      
+                      Button("Add") {
+                        let currentText = appState.isSearchMode ? appState.history.searchQuery : appState.promptText
+                        if !currentText.isEmpty {
+                          (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt(initialContents: currentText)
+                        }
+                      }
+                    }
+                }
+              } else {
+                ListView(universalItems: items)
+                  .frame(minWidth: 300)
+              }
             }
             
             // Preview pane (conditional with fixed width)

--- a/nozzle/Views/UnifiedInputFieldView.swift
+++ b/nozzle/Views/UnifiedInputFieldView.swift
@@ -208,14 +208,7 @@ struct UnifiedInputFieldView: View {
   
   @MainActor
   private func handleQueryChange(oldValue: String, newValue: String) {
-    // If user types "/" at the beginning in any mode, jump to Prompts
-    if oldValue.isEmpty && newValue == "/" {
-      contentManager.activeSourceId = "prompts"
-      // Set the search query to show slash commands
-      if let src = contentManager.sources["prompts"] {
-        src.searchQuery = newValue
-      }
-    }
+    // No special handling needed - query changes are handled by the binding
   }
   
   @MainActor
@@ -224,39 +217,9 @@ struct UnifiedInputFieldView: View {
     
     // Handle Prompts source specially
     if contentManager.activeSourceId == "prompts" {
-      // Slash commands
-      if text == "/add" {
-        let current = appState.promptText
-        guard !current.isEmpty,
-              let prompts = contentManager.sources["prompts"] as? PromptsSource else {
-          return
-        }
-        // Use first line as a sensible filename
-        let firstLine = current.split(whereSeparator: \.isNewline).first.map(String.init) ?? "Untitled"
-        _ = prompts.createNewPrompt(named: firstLine, initialContents: current)
-        query = "" // clear command
-        return
-      }
-      
-      if text == "/new" {
-        if let prompts = contentManager.sources["prompts"] as? PromptsSource,
-           let url = prompts.createNewPrompt() {
-          // After refresh, focus the new item and open editor in preview
-          Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(120))
-            if let item = contentManager.activeItems.first(where: { $0.fileURL == url }) {
-              contentManager.focus(item.id)
-            }
-          }
-        }
-        query = ""
-        return
-      }
-      
-      // No command: apply the first matching prompt
+      // Apply the first matching prompt
       if let first = contentManager.activeItems.first, 
-         let url = first.fileURL,
-         !(first.uniformTypeIdentifier?.hasPrefix("org.nozzle.command.") ?? false) {
+         let url = first.fileURL {
         (contentManager.sources["prompts"] as? PromptsSource)?.applyPrompt(at: url)
         appState.addPromptChip(url: url)
         // Switch to prompt mode so the user can keep editing the input


### PR DESCRIPTION
## Summary
Remove the redundant slash command functionality from the prompt menu and enhance the user experience with comprehensive right-click context menus for prompt creation and management.

## Changes Made

### Slash Command Removal
- **PromptsSource.swift**: Removed injection logic for `/new` and `/add` command items from the `items` computed property
- **UnifiedInputFieldView.swift**: Removed auto-navigation on "/" input and removed slash command handling from `handleSubmit()`
- Simplified prompt interface by eliminating redundant functionality

### Enhanced Right-Click Menus
- **ContentView.swift**: Added context menus to prompts ListView area (including empty space) with "New" and "Add" options
- **ContentView.swift**: Added context menu to the plus.circle button with "New", "Add", and "Open Prompts" options
- **Empty State**: Implemented informative empty state for prompts view with guidance text and right-click functionality

### Benefits
- **Consistency**: Single interaction pattern for prompt creation (right-click menus)
- **Discoverability**: Context menus available anywhere on prompts page, including empty space
- **Simplification**: Removed confusing dual-interface (slash commands + right-click)
- **User-Friendly**: Clear empty state messaging guides users to available functionality

## Test Plan
- [x] Right-click on empty prompts area shows "New" and "Add" options
- [x] Right-click on populated prompts list shows context menu
- [x] Right-click on plus.circle button shows expanded menu
- [x] "New" creates blank prompt, "Add" saves current input as prompt
- [x] Empty state displays helpful messaging
- [x] All slash command functionality removed without breaking existing features
- [x] Prompt creation and management works through right-click menus only

🤖 Generated with [Claude Code](https://claude.ai/code)