### PR TITLE
Fix unwanted auto-scroll on hover in universal lists

### DIFF
--- a/nozzle/Views/ListView.swift
+++ b/nozzle/Views/ListView.swift
@@ -192,8 +192,8 @@ struct ListView: View {
                         appState.scrollTarget = nil
                     }
                 }
-                .onChange(of: configuration.enableScrollTargeting ? nil : contentManager.focusedItemId) { _, newValue in
-                    guard !configuration.enableScrollTargeting,
+                .onChange(of: configuration.enableScrollTargeting ? contentManager.focusedItemId : nil) { _, newValue in
+                    guard configuration.enableScrollTargeting,
                           let id = newValue else { return }
                     withAnimation(.easeInOut(duration: 0.15)) {
                         proxy.scrollTo(id, anchor: .center)


### PR DESCRIPTION
## Summary
• Fixed automatic scrolling issue when hovering over items in universal lists (folders, prompts)
• The problem was caused by inverted logic in the onChange modifier for focusedItemId
• Universal lists now behave consistently with clipboard lists in terms of scroll behavior

## Problem
Users experienced unwanted automatic scrolling when hovering near the end of universal lists. This was happening because:
- The `onChange` modifier was monitoring `focusedItemId` changes for lists with `enableScrollTargeting: false` 
- When users hovered over items in universal lists, `contentManager.focus()` was called
- This triggered the onChange modifier, causing automatic scrolling to center the hovered item

## Solution
Inverted the logic in `ListView.swift` lines 195-201:
- **Before**: Monitored focus changes when `enableScrollTargeting` was `false` (universal lists)
- **After**: Only monitors focus changes when `enableScrollTargeting` is `true` (clipboard lists)

## Result
- **Clipboard lists**: Continue to scroll to focused items as intended
- **Universal lists**: No longer auto-scroll on hover, providing a better user experience

## Test plan
- [ ] Verify clipboard lists still scroll appropriately when navigating with keyboard
- [ ] Confirm universal lists (folders, prompts) no longer auto-scroll on hover
- [ ] Test that hovering near the end of universal lists doesn't cause unwanted scrolling

🤖 Generated with [Claude Code](https://claude.ai/code)