### PR TITLE
Fix prompt rename functionality and improve UI synchronization

### DIFF
--- a/nozzle.xcodeproj/project.pbxproj
+++ b/nozzle.xcodeproj/project.pbxproj
@@ -128,6 +128,8 @@
 		F50C3E262E65F9B900420829 /* FolderPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50C3E252E65F9B900420829 /* FolderPreviewView.swift */; };
 		F55A77CA2E5E37F50039E760 /* PromptsSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55A77C92E5E37F50039E760 /* PromptsSource.swift */; };
 		F55A77CC2E5E38000039E760 /* PromptEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55A77CB2E5E38000039E760 /* PromptEditorView.swift */; };
+		F569FB182E6E1BFA0076D784 /* WindowAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F569FB172E6E1BFA0076D784 /* WindowAccessor.swift */; };
+		F569FB192E6E1BFA0076D784 /* RenameEventCatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F569FB162E6E1BFA0076D784 /* RenameEventCatcher.swift */; };
 		F57274592E56720D003A9299 /* ContentSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57274582E56720D003A9299 /* ContentSourceType.swift */; };
 		F572745A2E56720D003A9299 /* ContentSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57274572E56720D003A9299 /* ContentSource.swift */; };
 		F572745B2E56720D003A9299 /* ContentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57274562E56720D003A9299 /* ContentItem.swift */; };
@@ -528,6 +530,8 @@
 		F50C3E252E65F9B900420829 /* FolderPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderPreviewView.swift; sourceTree = "<group>"; };
 		F55A77C92E5E37F50039E760 /* PromptsSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptsSource.swift; sourceTree = "<group>"; };
 		F55A77CB2E5E38000039E760 /* PromptEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptEditorView.swift; sourceTree = "<group>"; };
+		F569FB162E6E1BFA0076D784 /* RenameEventCatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameEventCatcher.swift; sourceTree = "<group>"; };
+		F569FB172E6E1BFA0076D784 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		F57274562E56720D003A9299 /* ContentItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentItem.swift; sourceTree = "<group>"; };
 		F57274572E56720D003A9299 /* ContentSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSource.swift; sourceTree = "<group>"; };
 		F57274582E56720D003A9299 /* ContentSourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSourceType.swift; sourceTree = "<group>"; };
@@ -866,6 +870,8 @@
 		F57274722E57C00B003A9299 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				F569FB162E6E1BFA0076D784 /* RenameEventCatcher.swift */,
+				F569FB172E6E1BFA0076D784 /* WindowAccessor.swift */,
 				F5C1805E2E63E4A5007ED483 /* CombinedContentBuilder.swift */,
 				F57274702E57C00B003A9299 /* FileTypeBadgeCache.swift */,
 				F57274712E57C00B003A9299 /* TextFileFormatter.swift */,
@@ -1210,6 +1216,8 @@
 				DAEE38471E3DBEB100DD2966 /* AppDelegate.swift in Sources */,
 				F57274692E567244003A9299 /* SecurityScopedBookmarks.swift in Sources */,
 				DAA072DF2C41C63C006DDFD2 /* ConfirmationView.swift in Sources */,
+				F569FB182E6E1BFA0076D784 /* WindowAccessor.swift in Sources */,
+				F569FB192E6E1BFA0076D784 /* RenameEventCatcher.swift in Sources */,
 				DAA365CE2C4BF9DD00A394F8 /* PinsSettingsPane.swift in Sources */,
 				DA3BCB8E2C3E015000B01BC1 /* ModifierFlags.swift in Sources */,
 				DA181177247D14DA00066D55 /* Settings.PaneIdentifier+Panes.swift in Sources */,

--- a/nozzle/Observables/AppState.swift
+++ b/nozzle/Observables/AppState.swift
@@ -480,4 +480,14 @@ class AppState {
     NotificationCenter.default.post(name: Self.focusInputNotification, object: nil)
   }
 
+  // Update a prompt chip's URL after a rename while preserving its id
+  func updatePromptChipURL(from oldURL: URL, to newURL: URL) {
+    if let idx = promptChips.firstIndex(where: { $0.url == oldURL }) {
+      let id = promptChips[idx].id
+      var updated = promptChips
+      updated[idx] = PromptChip(id: id, url: newURL)
+      promptChips = updated
+    }
+  }
+
 }

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -25,6 +25,11 @@ final class ContentManager {
     
     // Preview focus tracking
     private(set) var focusedItemId: UUID?
+    // Track active inline rename row globally so other clicks can cancel it
+    var renameActiveItemId: UUID?
+    
+    // Pending inline rename request for a specific item id
+    var pendingRenameItemId: UUID?
     
     // Cache for selected items to avoid repeated full scans and sorts
     @ObservationIgnored private var _selectedCache: [ContentItem] = []
@@ -214,6 +219,24 @@ final class ContentManager {
     
     func focus(_ id: UUID?) {
         focusedItemId = id
+    }
+    
+    // Request inline rename for a newly created/located item by URL (Prompts)
+    func requestRename(for url: URL) {
+        if let item = sources["prompts"]?.items.first(where: { $0.fileURL == url }) {
+            activeSourceId = "prompts"
+            focus(item.id)
+            pendingRenameItemId = item.id
+            renameActiveItemId = item.id
+        }
+    }
+
+    // Deterministic version that targets a known item id (avoids timing issues)
+    func requestRename(for id: UUID) {
+        activeSourceId = "prompts"
+        focus(id)
+        pendingRenameItemId = id
+        renameActiveItemId = id
     }
     
     // Called after folder expansion to handle selected folder states
@@ -422,6 +445,12 @@ final class ContentManager {
         if item.htmlData != nil { return true }
         return false
     }
+}
+
+// Global notifications for inline rename coordination
+extension Notification.Name {
+    static let CommitActiveRename = Notification.Name("ContentManager.CommitActiveRename")
+    static let CancelActiveRename = Notification.Name("ContentManager.CancelActiveRename")
 }
 
 // MARK: - Selected items caching helpers

--- a/nozzle/Observables/PromptsSource.swift
+++ b/nozzle/Observables/PromptsSource.swift
@@ -86,7 +86,13 @@ final class PromptsSource: ContentSource {
         let url = uniqueURL(basename: base, ext: ext)
         do {
             try TextFileFormatter.save(string: initialContents, to: url, type: .plainText)
-            Task { @MainActor in await inner.refresh() }
+            // Compute stable id deterministically now to avoid racing the refresh
+            let snap = FileIdentity.snapshot(for: url)
+            let id = FileSystemSource.makeStableUUID(identity: snap.identity, fallbackPath: url.absoluteString)
+            Task { @MainActor in
+                await inner.refresh()
+                ContentManager.shared.requestRename(for: id)
+            }
             return url
         } catch {
             NSSound.beep()
@@ -114,6 +120,76 @@ final class PromptsSource: ContentSource {
         Task { @MainActor in await inner.refresh() }
     }
 
+    @discardableResult
+    func renamePrompt(at oldURL: URL, to newDisplayName: String) -> URL? {
+        let fm = FileManager.default
+        let ext = oldURL.pathExtension.isEmpty ? Defaults[.promptsFileExtension] : oldURL.pathExtension
+        // Sanitize base name and strip extension if user typed one
+        var base = newDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if base.hasSuffix(".\(ext)") {
+            base = String(base.dropLast(ext.count + 1))
+        }
+        base = sanitizeFileName(base)
+        guard !base.isEmpty else { NSSound.beep(); return nil }
+
+        let newURL = folderURL.appendingPathComponent(base).appendingPathExtension(ext)
+
+        // No-op
+        if newURL == oldURL { return newURL }
+
+        // Conflict
+        if fm.fileExists(atPath: newURL.path) {
+            NSSound.beep(); return nil
+        }
+
+        do {
+            let currentBase = oldURL.deletingPathExtension().lastPathComponent
+            if currentBase.caseInsensitiveCompare(base) == .orderedSame {
+                // Case-only change on case-insensitive volumes: hop via a temp name
+                let tmp = uniqueURL(basename: "\(base)-tmp-\(UUID().uuidString.prefix(6))", ext: ext)
+                let coord = NSFileCoordinator()
+                var err: NSError?
+                // Move old -> tmp
+                coord.coordinate(writingItemAt: oldURL, options: .forMoving, writingItemAt: tmp, options: .forReplacing, error: &err) { src, dst in
+                    try? fm.moveItem(at: src, to: dst)
+                }
+                if err == nil {
+                    // Move tmp -> new
+                    coord.coordinate(writingItemAt: tmp, options: .forMoving, writingItemAt: newURL, options: .forReplacing, error: &err) { src, dst in
+                        try? fm.moveItem(at: src, to: dst)
+                    }
+                }
+                if err != nil { throw err! }
+            } else {
+                // Coordinated move so NSFilePresenter receives didMove
+                let coord = NSFileCoordinator()
+                var err: NSError?
+                coord.coordinate(writingItemAt: oldURL, options: .forMoving, writingItemAt: newURL, options: .forReplacing, error: &err) { src, dst in
+                    try? fm.moveItem(at: src, to: dst)
+                }
+                if let e = err { throw e }
+            }
+            
+            // Update UI and prompt chips
+            Task { @MainActor in
+                // First update the prompt chip URL immediately
+                AppState.shared.updatePromptChipURL(from: oldURL, to: newURL)
+                
+                // Then refresh the file list to show the new name
+                await self.inner.refresh()
+                
+                // Keep focus on the renamed item
+                if let renamedItem = self.items.first(where: { $0.fileURL == newURL }) {
+                    ContentManager.shared.focus(renamedItem.id)
+                }
+            }
+            return newURL
+        } catch {
+            NSSound.beep()
+            return nil
+        }
+    }
+
     func reveal(_ url: URL) {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
@@ -135,5 +211,15 @@ final class PromptsSource: ContentSource {
             idx += 1
         }
         return candidate
+    }
+
+    private func sanitizeFileName(_ name: String) -> String {
+        // Remove disallowed characters and collapse whitespace
+        let bad = CharacterSet(charactersIn: "/:")
+            .union(.newlines)
+            .union(.controlCharacters)
+        let cleaned = name.components(separatedBy: bad).joined(separator: " ")
+        return cleaned.replacingOccurrences(of: #"[\s]+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/nozzle/Observables/UniversalItemDecorator.swift
+++ b/nozzle/Observables/UniversalItemDecorator.swift
@@ -6,7 +6,7 @@ import UniformTypeIdentifiers
 @Observable @MainActor
 final class UniversalItemDecorator: ListItemDecorator {
     let id: UUID
-    private(set) var base: ContentItem
+    var base: ContentItem  // Made mutable so it can be updated
     let sourceId: String
     
     // Cached thumbnail for performance

--- a/nozzle/Utilities/RenameEventCatcher.swift
+++ b/nozzle/Utilities/RenameEventCatcher.swift
@@ -1,0 +1,74 @@
+import AppKit
+
+@MainActor
+final class RenameEventCatcher {
+    private var mouseMonitor: Any?
+    private var keyMonitor: Any?
+    private weak var window: NSWindow?
+    private var armed = false
+
+    /// Arm one-shot monitors when a rename starts
+    func arm(in window: NSWindow) {
+        guard !armed else { return }
+        self.window = window
+        armed = true
+
+        // Return commits, Escape cancels
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] e in
+            guard let self, self.armed else { return e }
+            switch e.keyCode {
+            case 36: // Return
+                NotificationCenter.default.post(name: .CommitActiveRename, object: nil)
+                return nil
+            case 53: // Escape
+                NotificationCenter.default.post(name: .CancelActiveRename, object: nil)
+                return nil
+            default:
+                return e
+            }
+        }
+
+        // First mouse click outside the inline TextField commits and is swallowed
+        mouseMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] e in
+            guard let self, self.armed, let win = self.window else { return e }
+
+            // Allow clicks inside the rename text field
+            if self.clickIsInsideRenameField(event: e, window: win) {
+                return e
+            }
+
+            // Commit and swallow the first click
+            NotificationCenter.default.post(name: .CommitActiveRename, object: nil)
+            self.disarm() // one-shot behavior
+            return nil
+        }
+    }
+
+    /// Disarm all monitors (call when rename completes/cancels)
+    func disarm() {
+        if let m = keyMonitor { NSEvent.removeMonitor(m) }
+        if let m = mouseMonitor { NSEvent.removeMonitor(m) }
+        keyMonitor = nil
+        mouseMonitor = nil
+        armed = false
+    }
+
+    // MARK: - Hit testing helper
+
+    @MainActor
+    private func clickIsInsideRenameField(event: NSEvent, window: NSWindow) -> Bool {
+        guard let contentView = window.contentView else { return false }
+        let p = contentView.convert(event.locationInWindow, from: nil)
+        guard let hit = contentView.hitTest(p) else { return false }
+
+        // Heuristic: SwiftUI TextField uses NSTextField; also allow clicks in the field editor
+        var v: NSView? = hit
+        while let current = v {
+            if current is NSTextField || current is NSSearchField { return true }
+            if let tv = window.firstResponder as? NSTextView,
+               current === tv.enclosingScrollView || current === tv.superview { return true }
+            v = current.superview
+        }
+        return false
+    }
+}

--- a/nozzle/Utilities/WindowAccessor.swift
+++ b/nozzle/Utilities/WindowAccessor.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import AppKit
+
+struct WindowAccessor: NSViewRepresentable {
+    let onResolve: (NSWindow) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        ResolverView(onResolve: onResolve)
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    private final class ResolverView: NSView {
+        let onResolve: (NSWindow) -> Void
+        init(onResolve: @escaping (NSWindow) -> Void) {
+            self.onResolve = onResolve
+            super.init(frame: .zero)
+        }
+        required init?(coder: NSCoder) { fatalError() }
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if let w = window { onResolve(w) }
+        }
+    }
+}
+

--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -8,6 +8,8 @@ struct ContentView: View {
   @State private var selectedTab = "clipboard"
   @State private var contentManager = ContentManager.shared
   @State private var dictationManager = DictationManager.shared
+  @State private var renameCatcher = RenameEventCatcher()
+  @State private var hostWindow: NSWindow?
   
   // Tab pagination state
   @State private var currentTabPage = 0
@@ -509,6 +511,8 @@ struct ContentView: View {
       }
     }
     .modifier(LiquidGlassModifier(reduceTransparency: reduceTransparency))
+    // Host window accessor for global rename event monitors
+    .background(WindowAccessor { win in hostWindow = win })
     .onAppear {
       inputFocused = true
       // Ensure first item is selected on appear
@@ -520,6 +524,18 @@ struct ContentView: View {
           appState.isKeyboardNavigating = true
         }
       }
+    }
+    // Arm/disarm one-shot monitors when inline rename starts/ends
+    .onChange(of: contentManager.renameActiveItemId) { _, newValue in
+      if let win = hostWindow, newValue != nil {
+        if NSApp.modalWindow == nil { renameCatcher.arm(in: win) }
+      } else {
+        renameCatcher.disarm()
+      }
+    }
+    // Safety: disarm if window resigns key
+    .onReceive(NotificationCenter.default.publisher(for: NSWindow.didResignKeyNotification)) { _ in
+      renameCatcher.disarm()
     }
     .onChange(of: contentManager.activeSourceId) { _, newSourceId in
       // Sync selectedTab when activeSourceId changes (e.g., from "/" shortcut)

--- a/nozzle/Views/KeyHandlingView.swift
+++ b/nozzle/Views/KeyHandlingView.swift
@@ -21,6 +21,11 @@ struct KeyHandlingView<Content: View>: View {
   var body: some View {
     content()
       .onKeyPress { _ in
+        // When inline rename is active anywhere, let focused controls (e.g., TextField/TextEditor)
+        // handle keys like Enter/Escape without global interception.
+        if contentManager.renameActiveItemId != nil {
+          return .ignored
+        }
         // Unfortunately, key presses don't allow access to
         // key code and don't properly work with multiple inputs,
         // so pressing ⌘, on non-English layout doesn't open

--- a/nozzle/Views/ListItemView.swift
+++ b/nozzle/Views/ListItemView.swift
@@ -50,6 +50,10 @@ struct ListItemView<Title: View>: View {
   }
   
   private var shouldShowHoverBackground: Bool {
+    // Freeze to the renaming item as active; suppress hover background for others
+    if let activeRename = contentManager.renameActiveItemId, activeRename != id {
+      return false
+    }
     // Immediate hover background only when not keyboard navigating
     if isHovering && !appState.isKeyboardNavigating { return true }
 
@@ -191,6 +195,10 @@ struct ListItemView<Title: View>: View {
       appState.isKeyboardNavigating = false
     }
     .onHover { hovering in
+      // During inline rename anywhere, freeze hover-driven selection changes
+      if contentManager.renameActiveItemId != nil {
+        return
+      }
       isHovering = hovering
       // Track hovered row globally to coordinate background across rows
       if hovering {

--- a/nozzle/Views/ListView.swift
+++ b/nozzle/Views/ListView.swift
@@ -245,7 +245,8 @@ struct ListView: View {
                 .id(item.id)
         } else if let universalItem = item as? UniversalItemDecorator {
             UniversalItemView(item: universalItem)
-                .id(item.id)
+                // Use a composite ID that includes the title to force view recreation on rename
+                .id("\(item.id):\(universalItem.title)")
         }
     }
 }

--- a/nozzle/Views/Preview/PreviewPaneView.swift
+++ b/nozzle/Views/Preview/PreviewPaneView.swift
@@ -5,6 +5,7 @@ import UniformTypeIdentifiers
 struct PreviewPaneView: View {
     let clipboardItem: HistoryItemDecorator?
     let fileItem: ContentItem?
+    @Environment(ContentManager.self) private var contentManager
 
     var body: some View {
         VStack(spacing: 0) {
@@ -82,6 +83,12 @@ struct PreviewPaneView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .previewSurfaceStyle()
+        // Clicking into the preview should commit any active inline rename first
+        .simultaneousGesture(TapGesture().onEnded {
+            if contentManager.renameActiveItemId != nil {
+                NotificationCenter.default.post(name: .CommitActiveRename, object: nil)
+            }
+        })
     }
 }
 

--- a/nozzle/Views/Preview/PromptEditorView.swift
+++ b/nozzle/Views/Preview/PromptEditorView.swift
@@ -4,7 +4,8 @@ import Foundation
 
 // Inline file presenter to avoid additional dependencies
 private class InlineFilePresenter: NSObject, NSFilePresenter {
-    let presentedItemURL: URL?
+    // Must be mutable so we can follow file moves/renames
+    var presentedItemURL: URL?
     let presentedItemOperationQueue: OperationQueue = {
         let q = OperationQueue()
         q.maxConcurrentOperationCount = 1
@@ -12,6 +13,7 @@ private class InlineFilePresenter: NSObject, NSFilePresenter {
     }()
 
     var onChange: (() -> Void)?
+    var onMove: ((URL) -> Void)?
 
     init(url: URL, onChange: (() -> Void)? = nil) {
         self.presentedItemURL = url
@@ -21,6 +23,12 @@ private class InlineFilePresenter: NSObject, NSFilePresenter {
 
     func presentedItemDidChange() {
         onChange?()
+    }
+
+    // Follow file when it’s renamed or moved
+    func presentedItemDidMove(to newURL: URL) {
+        presentedItemURL = newURL
+        onMove?(newURL)
     }
 }
 
@@ -133,11 +141,27 @@ struct PromptEditorView: View {
             .onChange(of: item.id) { _, _ in
                 // Save and tear down previous bindings before switching
                 saveWork?.cancel()
-                saveImmediately() // save to previous file via currentFileURL
+                // Only save to the previous file if its URL hasn't just changed (rename case)
+                if item.fileURL == currentFileURL {
+                    saveImmediately() // save to previous file via currentFileURL
+                }
                 removePresenter()
 
                 // Reset state and switch to the new item
                 currentItemId = item.id
+                currentFileURL = item.fileURL
+                hasExternalChange = false
+                isDirty = false
+                isEditing = false
+                load()
+                setupPresenter()
+            }
+            .onChange(of: item.fileURL) { _, _ in
+                // Handle file renames/moves that keep the same identity/UUID
+                // Important: do NOT save to the old URL here, as that would resurrect the old filename.
+                saveWork?.cancel()
+                removePresenter()
+
                 currentFileURL = item.fileURL
                 hasExternalChange = false
                 isDirty = false
@@ -150,6 +174,8 @@ struct PromptEditorView: View {
                 saveImmediately()
                 removePresenter()
             }
+            // Guard against rename races: when a global rename commit happens, pause reactions briefly
+            // Note: rename commits are coordinated elsewhere; no special pause needed here
     }
     
     private func load() {
@@ -182,6 +208,14 @@ struct PromptEditorView: View {
                     return
                 }
                 self.load()
+            }
+        }
+        p.onMove = { newURL in
+            DispatchQueue.main.async {
+                // Point the editor at the new file path so future saves don’t resurrect the old name
+                self.currentFileURL = newURL
+                // Grace period to ignore our own subsequent change notifications
+                self.ignoreChangesUntil = Date().addingTimeInterval(1.0)
             }
         }
         NSFileCoordinator.addFilePresenter(p)

--- a/nozzle/Views/UnifiedInputFieldView.swift
+++ b/nozzle/Views/UnifiedInputFieldView.swift
@@ -213,7 +213,7 @@ struct UnifiedInputFieldView: View {
   
   @MainActor
   private func handleSubmit() {
-    let text = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    // let _ = query.trimmingCharacters(in: .whitespacesAndNewlines) // trimming not used here currently
     
     // Handle Prompts source specially
     if contentManager.activeSourceId == "prompts" {

--- a/nozzle/Views/UniversalItemView.swift
+++ b/nozzle/Views/UniversalItemView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Defaults
+import AppKit
 
 @MainActor
 private extension UniversalItemView {
@@ -7,10 +8,82 @@ private extension UniversalItemView {
     static var previewHoverThrottler = Throttler(minimumDelay: 0.2)
 }
 
+// Local inline text field that selects only the base name (excluding extension)
+private struct InlineBaseNameTextField: NSViewRepresentable {
+    @Binding var text: String
+    let ext: String
+    let onSubmit: () -> Void
+    let onCancel: () -> Void
+
+    func makeNSView(context: Context) -> NSTextField {
+        let tf = NSTextField(string: text)
+        tf.isBordered = false
+        tf.isBezeled = false
+        tf.drawsBackground = false
+        tf.focusRingType = .none
+        tf.target = context.coordinator
+        tf.action = #selector(Coordinator.submit(_:))
+        tf.delegate = context.coordinator
+        DispatchQueue.main.async { selectBase(tf) }
+        return tf
+    }
+
+    func updateNSView(_ tf: NSTextField, context: Context) {
+        if tf.stringValue != text { tf.stringValue = text }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        let parent: InlineBaseNameTextField
+        init(_ parent: InlineBaseNameTextField) { self.parent = parent }
+        
+        @objc func submit(_ sender: Any?) {
+            // Update the binding with the current text field value before submitting
+            if let textField = sender as? NSTextField {
+                parent.text = textField.stringValue
+            }
+            parent.onSubmit()
+        }
+        
+        func controlTextDidChange(_ obj: Notification) {
+            guard let textField = obj.object as? NSTextField else { return }
+            parent.text = textField.stringValue
+        }
+        
+        func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            switch commandSelector {
+            case #selector(NSResponder.cancelOperation(_:)):
+                parent.onCancel(); return true
+            case #selector(NSResponder.insertNewline(_:)):
+                // Update text before submitting
+                if let textField = control as? NSTextField {
+                    parent.text = textField.stringValue
+                }
+                parent.onSubmit(); return true
+            default: return false
+            }
+        }
+    }
+
+    private func selectBase(_ tf: NSTextField) {
+        tf.window?.makeFirstResponder(tf)
+        let s = tf.stringValue as NSString
+        let hasExt = s.range(of: ".\(ext)", options: [.backwards, .anchored]).location != NSNotFound
+        let baseLen = hasExt ? max(0, s.length - (ext.count + 1)) : s.length
+        if let editor = tf.window?.fieldEditor(true, for: tf) {
+            editor.selectedRange = NSRange(location: 0, length: baseLen)
+        }
+    }
+}
+
 struct UniversalItemView: View {
     @Bindable var item: UniversalItemDecorator
     @Environment(AppState.self) private var appState
     @Environment(ContentManager.self) private var contentManager
+    @State private var isRenaming: Bool = false
+    @State private var editingName: String = ""
+    @FocusState private var renameFocused: Bool
     
     var body: some View {
         Group {
@@ -38,12 +111,14 @@ struct UniversalItemView: View {
                         selectionSymbolColor: (item.isExample ? .yellow : .white),
                         selectionBackgroundColor: (item.isExample ? .yellow : nil),
                         onCopyAction: { item.copyToClipboard() }
-                    ) {
-                        Text(verbatim: item.title)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
+                    ) { titleView() }
                     .onTapGesture { location in
+                        if isRenaming { finishRename(); return }
+                        // If another row is in rename mode, clicking here should exit rename mode and do nothing else
+                        if let activeRename = contentManager.renameActiveItemId, activeRename != item.id {
+                            NotificationCenter.default.post(name: .CommitActiveRename, object: nil)
+                            return
+                        }
                         // Check if click is in the checkbox/selection area (right 60 pixels)
                         let selectionAreaThreshold: CGFloat = 42
                         let frameWidth: CGFloat = 300  // Approximate width
@@ -52,6 +127,11 @@ struct UniversalItemView: View {
                             // Toggle example state when clicking the selected checkmark area
                             contentManager.toggleExample(item.id)
                         } else {
+                            // Command-click to rename (Prompts only)
+                            if item.base.sourceId == "prompts", NSEvent.modifierFlags.contains(.command) {
+                                beginRename()
+                                return
+                            }
                             // Special handling for Prompts: add as chip instead of aggregated selection
                             if item.base.sourceId == "prompts",
                                !(item.base.uniformTypeIdentifier?.hasPrefix("org.nozzle.command.") ?? false),
@@ -77,6 +157,8 @@ struct UniversalItemView: View {
                         }
                     }
                     .onHover { hovering in
+                        // Freeze focus changes due to hover while any rename is active
+                        if contentManager.renameActiveItemId != nil { return }
                         if hovering {
                             // Debounce focus so we only preview when the pointer "dwells"
                             UniversalItemView.previewHoverThrottler.minimumDelay = Double(Defaults[.hoverPreviewDelay]) / 1000
@@ -119,6 +201,9 @@ struct UniversalItemView: View {
                 Button("Duplicate") {
                     (contentManager.sources["prompts"] as? PromptsSource)?.duplicatePrompt(at: url)
                 }
+                Button("Rename…") {
+                    beginRename()
+                }
                 Button("Delete", role: .destructive) {
                     (contentManager.sources["prompts"] as? PromptsSource)?.deletePrompt(at: url)
                 }
@@ -156,5 +241,107 @@ struct UniversalItemView: View {
                 }
             }
         }
+        .onChange(of: contentManager.pendingRenameItemId) { _, newValue in
+            guard let pending = newValue else { return }
+            if pending == item.id {
+                beginRename()
+                // Clear the request so other rows don't respond
+                contentManager.pendingRenameItemId = nil
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .CommitActiveRename)) { _ in
+            if isRenaming { finishRename() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .CancelActiveRename)) { _ in
+            if isRenaming { cancelRename() }
+        }
+        .onAppear {
+            // If a rename was requested before this row appeared, handle it now
+            if contentManager.pendingRenameItemId == item.id {
+                beginRename()
+                contentManager.pendingRenameItemId = nil
+            }
+        }
+        .onChange(of: contentManager.renameActiveItemId) { _, active in
+            // If another row becomes the active rename or rename is cleared, exit local rename mode
+            if let active, active != item.id { if isRenaming { isRenaming = false } }
+        }
+    }
+}
+
+// MARK: - Rename helpers (Prompts only)
+private extension UniversalItemView {
+    @ViewBuilder
+    func titleView() -> some View {
+        if isRenaming && item.base.sourceId == "prompts" && !item.base.isFolder {
+            let ext = (item.base.fileURL?.pathExtension.isEmpty == false)
+                ? (item.base.fileURL?.pathExtension ?? Defaults[.promptsFileExtension])
+                : Defaults[.promptsFileExtension]
+            InlineBaseNameTextField(
+                text: $editingName,
+                ext: ext,
+                onSubmit: { finishRename() },
+                onCancel: { cancelRename() }
+            )
+            .focused($renameFocused)
+            .onChange(of: renameFocused) { _, focused in
+                if !focused { finishRename() }
+            }
+            // Swallow row-level taps while renaming to ensure commit-first
+            .highPriorityGesture(TapGesture())
+            // Last-chance commit if the row disappears due to refresh/navigation
+            .onDisappear { if isRenaming { finishRename() } }
+        } else {
+            Text(verbatim: item.title)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+    func beginRename() {
+        guard item.base.sourceId == "prompts", !item.base.isFolder else { return }
+        contentManager.focus(item.id)
+        editingName = displayNameWithoutExtension()
+        isRenaming = true
+        contentManager.renameActiveItemId = item.id
+        DispatchQueue.main.async { renameFocused = true }
+    }
+
+    func finishRename() {
+        guard isRenaming else { return }
+        let newBase = editingName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = item.base.fileURL else { return }
+        let currentBase = url.deletingPathExtension().lastPathComponent
+        // Empty name: keep editing, beep, refocus
+        if newBase.isEmpty {
+            NSSound.beep()
+            DispatchQueue.main.async { renameFocused = true }
+            return
+        }
+        // No change: exit rename mode quietly
+        if newBase == currentBase {
+            isRenaming = false
+            contentManager.renameActiveItemId = nil
+            return
+        }
+        // Attempt rename; only exit on success
+        if let _ = (contentManager.sources["prompts"] as? PromptsSource)?.renamePrompt(at: url, to: newBase) {
+            isRenaming = false
+            contentManager.renameActiveItemId = nil
+        } else {
+            // Conflict or failure: keep editing and refocus so user can fix
+            DispatchQueue.main.async { renameFocused = true }
+        }
+    }
+
+    func displayNameWithoutExtension() -> String {
+        if let url = item.base.fileURL {
+            return url.deletingPathExtension().lastPathComponent
+        }
+        return item.title
+    }
+
+    func cancelRename() {
+        isRenaming = false
+        contentManager.renameActiveItemId = nil
     }
 }


### PR DESCRIPTION
## Summary
- Fixes inline rename functionality for prompt files that was not committing changes properly
- Resolves UI synchronization issues where renamed files showed old names temporarily
- Ensures renamed items maintain focus and display correctly after refresh

## Problem
The rename feature had several issues:
1. Text entered during rename was not being saved when committing (Enter or click-away)
2. After rename, the UI would show the old name temporarily and items would reorder
3. The new name would only appear after reopening the prompts menu

## Solution
### Text Field Synchronization
- Added `controlTextDidChange` delegate method to sync text as user types
- Modified `submit` method to capture current text value before committing
- Ensures entered text is properly saved to the binding

### Force View Recreation
- Changed view ID from `item.id` to composite `"\(item.id):\(universalItem.title)"`
- Forces SwiftUI to recreate views when title changes after rename
- Eliminates stale view caching issues

### Additional Improvements
- Added rename event monitoring to handle clicks outside rename field
- Improved focus management during rename operations
- Made decorator base mutable to allow updates
- Added proper cleanup of rename state on cancel or completion

## Test Plan
- [x] Command+click on a prompt file initiates inline rename
- [x] Right-click menu "Rename..." option works
- [x] Typing in rename field updates the binding correctly
- [x] Pressing Enter commits the rename and saves to disk
- [x] Clicking outside the rename field commits the rename
- [x] Pressing Escape cancels the rename
- [x] Renamed files show new name immediately in UI
- [x] Renamed files maintain focus after refresh
- [x] Files reorder to correct alphabetical position after rename
- [x] No need to reopen menu to see renamed files

🤖 Generated with [Claude Code](https://claude.ai/code)