### PR TITLE
Fix prompt menu right-click behavior for consistent UX

### DIFF
--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -434,46 +434,41 @@ struct ContentView: View {
               let items = contentManager.getDecorators(for: contentManager.activeSourceId)
               
               if contentManager.activeSourceId == "prompts" {
-                // Add context menu for prompts view with empty state
-                if items.isEmpty {
-                  VStack {
-                    Spacer()
-                    Text("No prompts found")
-                      .font(.system(size: 14))
-                      .foregroundColor(.secondary)
-                    Text("Right-click to create your first prompt")
-                      .font(.system(size: 12))
-                      .foregroundColor(Color.secondary.opacity(0.7))
-                    Spacer()
+                // Wrap entire prompts view in a container with consistent context menu
+                ZStack {
+                  // Background that fills entire area and responds to right-clicks
+                  Color.clear
+                    .contentShape(Rectangle())
+                  
+                  if items.isEmpty {
+                    VStack {
+                      Spacer()
+                      Text("No prompts found")
+                        .font(.system(size: 14))
+                        .foregroundColor(.secondary)
+                      Text("Right-click to create your first prompt")
+                        .font(.system(size: 12))
+                        .foregroundColor(Color.secondary.opacity(0.7))
+                      Spacer()
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                  } else {
+                    ListView(universalItems: items)
+                      .frame(minWidth: 300, maxHeight: .infinity)
                   }
-                  .frame(minWidth: 300, maxWidth: .infinity)
-                  .contextMenu {
-                    Button("New") {
-                      (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt()
-                    }
-                    
-                    Button("Add") {
-                      let currentText = appState.isSearchMode ? appState.history.searchQuery : appState.promptText
-                      if !currentText.isEmpty {
-                        (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt(initialContents: currentText)
-                      }
+                }
+                .frame(minWidth: 300, maxWidth: .infinity, maxHeight: .infinity)
+                .contextMenu {
+                  Button("New") {
+                    (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt()
+                  }
+                  
+                  Button("Add") {
+                    let currentText = appState.isSearchMode ? appState.history.searchQuery : appState.promptText
+                    if !currentText.isEmpty {
+                      (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt(initialContents: currentText)
                     }
                   }
-                } else {
-                  ListView(universalItems: items)
-                    .frame(minWidth: 300)
-                    .contextMenu {
-                      Button("New") {
-                        (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt()
-                      }
-                      
-                      Button("Add") {
-                        let currentText = appState.isSearchMode ? appState.history.searchQuery : appState.promptText
-                        if !currentText.isEmpty {
-                          (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt(initialContents: currentText)
-                        }
-                      }
-                    }
                 }
               } else {
                 ListView(universalItems: items)


### PR DESCRIPTION
## Summary
Fixed the prompt menu right-click behavior to work anywhere in the empty view area, not just on text elements.

## Problem
Previously, when viewing prompts with an empty state, users could only access the context menu by right-clicking directly on the "No prompts found" or "Right-click to create your first prompt" text. This created an inconsistent and frustrating user experience where large areas of the view were unresponsive to right-clicks.

## Solution
- Replaced the VStack container with a ZStack for the prompts view
- Added an invisible `Color.clear` background with `.contentShape(Rectangle())` that fills the entire area
- Applied the context menu to the entire ZStack container
- Now right-clicks work consistently across the entire prompts view area

## Test plan
- [x] Build compiles successfully 
- [ ] Test right-clicking anywhere in empty prompts view triggers context menu
- [ ] Test right-clicking still works on prompt items when prompts exist
- [ ] Verify "New" and "Add" context menu options work correctly
- [ ] Test on both empty and populated prompt states

🤖 Generated with [Claude Code](https://claude.ai/code)