### PR TITLE
Fix rename commit on empty space clicks and enable empty prompt creation

### DIFF
--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -181,9 +181,7 @@ struct ContentView: View {
                   
                   Button("Add") {
                     let currentText = appState.promptText
-                    if !currentText.isEmpty {
-                      (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt(initialContents: currentText)
-                    }
+                    (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt(initialContents: currentText)
                   }
                   
                   Divider()
@@ -397,6 +395,11 @@ struct ContentView: View {
                   Spacer()
                 }
                 .frame(minWidth: 300, maxWidth: .infinity)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                  // Commit any active rename when clicking empty space
+                  NotificationCenter.default.post(name: .CommitActiveRename, object: nil)
+                }
               } else {
                 ListView(contextItems: contextItems, exampleItems: exampleItems)
                   .contextMenu {
@@ -447,6 +450,11 @@ struct ContentView: View {
                     Spacer()
                   }
                   .frame(minWidth: 300, maxWidth: .infinity)
+                  .contentShape(Rectangle())
+                  .onTapGesture {
+                    // Commit any active rename when clicking empty space
+                    NotificationCenter.default.post(name: .CommitActiveRename, object: nil)
+                  }
                   .contextMenu {
                     Button("New") {
                       (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt()
@@ -454,9 +462,7 @@ struct ContentView: View {
                     
                     Button("Add") {
                       let currentText = appState.isSearchMode ? appState.history.searchQuery : appState.promptText
-                      if !currentText.isEmpty {
-                        (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt(initialContents: currentText)
-                      }
+                      (contentManager.sources["prompts"] as? PromptsSource)?.createNewPrompt(initialContents: currentText)
                     }
                   }
                 } else {

--- a/nozzle/Views/ListView.swift
+++ b/nozzle/Views/ListView.swift
@@ -236,6 +236,11 @@ struct ListView: View {
             .contentMargins(.leading, 10, for: .scrollIndicators)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            // Commit any active rename when clicking empty space in the list
+            NotificationCenter.default.post(name: .CommitActiveRename, object: nil)
+        }
     }
     
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Fix rename operations not committing when clicking in empty space areas
- Enable creation of empty prompts through "Add" context menu option
- Improve overall user experience with rename functionality

## Changes Made

### Rename Commit Fixes
- **ContentView**: Added tap gesture handling to empty state views ("No items selected", "No prompts found")
- **ListView**: Added tap gesture to ScrollView to capture clicks in empty space below content list
- Both changes post `CommitActiveRename` notification to properly exit rename mode

### Empty Prompt Creation
- Removed empty text restrictions from "Add" context menu buttons in both locations
- Users can now create empty prompts that can be edited later

## Test Plan
- [x] Test rename functionality by starting a rename and clicking in various empty areas
- [x] Verify empty space clicks in aggregated view commit renames
- [x] Verify empty space clicks in prompts empty state commit renames  
- [x] Verify empty space clicks below content lists commit renames
- [x] Test "Add" context menu creates empty prompts when no text is present
- [x] Verify existing rename commit behavior on items and non-empty areas still works

🤖 Generated with [Claude Code](https://claude.ai/code)