### PR TITLE
Improve mic mode with better sounds and comprehensive exit handling

### DIFF
--- a/nozzle/Extensions/NSSound+Named.swift
+++ b/nozzle/Extensions/NSSound+Named.swift
@@ -5,4 +5,35 @@ extension NSSound {
     contentsOf: Bundle.main.url(forResource: "Knock", withExtension: "caf")!, byReference: true)
   static let write = NSSound(
     contentsOf: Bundle.main.url(forResource: "Write", withExtension: "caf")!, byReference: true)
+  
+  // Dictation sounds - use macOS dictation sounds with fallbacks
+  static var dictationBegin: NSSound? {
+    // Try macOS dictation sound first
+    if let url = URL(string: "file:///System/Library/PrivateFrameworks/AssistantServices.framework/Versions/A/Resources/dt-begin.caf"),
+       let sound = NSSound(contentsOf: url, byReference: true) {
+      return sound
+    }
+    // Fallback to system sound
+    return NSSound(named: "Hero")
+  }
+  
+  static var dictationConfirm: NSSound? {
+    // Try macOS dictation sound first
+    if let url = URL(string: "file:///System/Library/PrivateFrameworks/AssistantServices.framework/Versions/A/Resources/dt-confirm.caf"),
+       let sound = NSSound(contentsOf: url, byReference: true) {
+      return sound
+    }
+    // Fallback to system sound
+    return NSSound(named: "Glass")
+  }
+  
+  static var dictationCancel: NSSound? {
+    // Try macOS dictation sound first
+    if let url = URL(string: "file:///System/Library/PrivateFrameworks/AssistantServices.framework/Versions/A/Resources/dt-cancel.caf"),
+       let sound = NSSound(contentsOf: url, byReference: true) {
+      return sound
+    }
+    // Fallback to system sound
+    return NSSound(named: "Funk")
+  }
 }

--- a/nozzle/Observables/DictationManager.swift
+++ b/nozzle/Observables/DictationManager.swift
@@ -33,6 +33,8 @@ final class DictationManager {
     
     private var targetTextBinding: Binding<String>?
     private var analyzerFormat: AVAudioFormat?
+    // Store the original text before dictation starts to prevent duplication
+    private var originalText: String = ""
     // Streaming task so we don't block the main actor
     private var audioStreamTask: Task<Void, Never>?
     
@@ -65,7 +67,7 @@ final class DictationManager {
         debugLog("toggleDictation called, isRecording: \(isRecording)")
         
         if isRecording {
-            await stopDictation()
+            await stopDictation(saveTranscription: true)
         } else {
             await startDictation(for: textBinding)
         }
@@ -82,11 +84,12 @@ final class DictationManager {
         }
         
         targetTextBinding = textBinding
+        originalText = textBinding.wrappedValue
         finalizedTranscript = ""
         volatileTranscript = ""
         
-        // Play system sound for start recording
-        NSSound.beep()
+        // Play dictation start sound
+        NSSound.dictationBegin?.play()
         
         isRecording = true
         debugLog("Set isRecording = true")
@@ -113,13 +116,13 @@ final class DictationManager {
     }
     
     @MainActor
-    private func stopDictation() async {
+    func stopDictation(saveTranscription: Bool = true) async {
         debugLog("Stopping dictation session")
         isCleaningUp = true
         isRecording = false
         
-        // Play system sound for stop recording
-        NSSound.beep()
+        // Play dictation stop sound
+        NSSound.dictationConfirm?.play()
         
         // Clean shutdown sequence - follow proper order
         debugLog("Starting cleanup sequence")
@@ -163,12 +166,16 @@ final class DictationManager {
         recognitionTask?.cancel()
         recognitionTask = nil
         
-        // Update text binding with finalized transcript
-        if !finalizedTranscript.characters.isEmpty, let binding = targetTextBinding {
-            let currentText = binding.wrappedValue
-            let separator = currentText.isEmpty ? "" : " "
-            binding.wrappedValue = currentText + separator + String(finalizedTranscript.characters)
-            debugLog("Updated text binding with finalized transcript")
+        // Handle transcription based on saveTranscription parameter
+        if saveTranscription {
+            // Final text is already in the binding from updateTargetText() calls
+            debugLog("Dictation session completed - final text saved")
+        } else {
+            // Restore original text (cancel transcription)
+            if let binding = targetTextBinding {
+                binding.wrappedValue = originalText
+                debugLog("Dictation session cancelled - original text restored")
+            }
         }
         
         // Clean up
@@ -244,19 +251,20 @@ final class DictationManager {
     @MainActor
     private func updateTargetText() {
         guard let binding = targetTextBinding else { return }
-        let currentText = binding.wrappedValue
         
-        var baseText = currentText
-        if !finalizedTranscript.characters.isEmpty {
-            let separator = currentText.isEmpty ? "" : " "
-            baseText = currentText + separator + String(finalizedTranscript.characters)
+        // Build the complete transcription for this session
+        var sessionTranscript = String(finalizedTranscript.characters)
+        if !volatileTranscript.characters.isEmpty {
+            let separator = sessionTranscript.isEmpty ? "" : " "
+            sessionTranscript += separator + String(volatileTranscript.characters)
         }
         
-        if !volatileTranscript.characters.isEmpty {
-            let separator = baseText.isEmpty ? "" : " "
-            binding.wrappedValue = baseText + separator + String(volatileTranscript.characters)
+        // Show original text + current session transcription
+        if !sessionTranscript.isEmpty {
+            let separator = originalText.isEmpty ? "" : " "
+            binding.wrappedValue = originalText + separator + sessionTranscript
         } else {
-            binding.wrappedValue = baseText
+            binding.wrappedValue = originalText
         }
     }
     
@@ -436,6 +444,13 @@ final class DictationManager {
         }
         
         debugLog("=== CRASH TEST END ===")
+    }
+    
+    @MainActor
+    func cancelDictation() async {
+        // Play cancel sound and stop without saving
+        NSSound.dictationCancel?.play()
+        await stopDictation(saveTranscription: false)
     }
 }
 

--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -124,6 +124,13 @@ struct ContentView: View {
           }
           .onChange(of: scenePhase) {
             if scenePhase == .background {
+              // Stop dictation when app loses focus
+              if dictationManager.isRecording {
+                Task {
+                  await dictationManager.stopDictation(saveTranscription: true)
+                }
+              }
+              
               if !appState.history.searchQuery.isEmpty {
                 appState.history.searchQuery = ""
               }
@@ -491,6 +498,14 @@ struct ContentView: View {
                 fileItem: contentManager.activeSourceId == "clipboard" ? nil : contentManager.focusedContentItem
               )
               .frame(width: 350)
+            }
+          }
+          .onTapGesture {
+            // Stop dictation when clicking outside the input field
+            if dictationManager.isRecording {
+              Task {
+                await dictationManager.stopDictation(saveTranscription: true)
+              }
             }
           }
         }

--- a/nozzle/Views/UnifiedInputFieldView.swift
+++ b/nozzle/Views/UnifiedInputFieldView.swift
@@ -8,6 +8,7 @@ struct UnifiedInputFieldView: View {
 
   @Environment(AppState.self) private var appState
   @Environment(ContentManager.self) private var contentManager
+  @State private var dictationManager = DictationManager.shared
   
   // State for dynamic text height
   @State private var textHeight: CGFloat = 20  // Start with single line height
@@ -97,6 +98,15 @@ struct UnifiedInputFieldView: View {
               .onSubmit {
                 handleSubmit()
               }
+              .onKeyPress(keys: [.escape]) { _ in
+                if dictationManager.isRecording {
+                  Task {
+                    await dictationManager.cancelDictation()
+                  }
+                  return .handled
+                }
+                return .ignored
+              }
               .onChange(of: query) { oldValue, newValue in
                 handleQueryChange(oldValue: oldValue, newValue: newValue)
               }
@@ -148,7 +158,13 @@ struct UnifiedInputFieldView: View {
                   textHeight = calculateTextHeight(query, width: newWidth - 20) // Account for clear button space
                 }
                 .onKeyPress(keys: [.return]) { keyPress in
-                  if keyPress.modifiers.contains(.shift) {
+                  if dictationManager.isRecording {
+                    // Enter key while recording - confirm and save transcription
+                    Task {
+                      await dictationManager.stopDictation(saveTranscription: true)
+                    }
+                    return .handled
+                  } else if keyPress.modifiers.contains(.shift) {
                     // Let TextEditor handle Shift+Enter naturally (creates newline)
                     return .ignored
                   } else {
@@ -156,6 +172,16 @@ struct UnifiedInputFieldView: View {
                     handleSubmit()
                     return .handled
                   }
+                }
+                .onKeyPress(keys: [.escape]) { _ in
+                  if dictationManager.isRecording {
+                    // Escape key while recording - cancel transcription
+                    Task {
+                      await dictationManager.cancelDictation()
+                    }
+                    return .handled
+                  }
+                  return .ignored
                 }
                 .onAppear {
                   fieldWidth = geometry.size.width


### PR DESCRIPTION
## Summary
• Replace generic beeps with macOS dictation sounds (dt-begin/confirm/cancel.caf with system fallbacks)
• Add comprehensive exit methods: Enter (save), Escape (cancel), window focus lost, click outside
• Fix text duplication issue by properly tracking original text state before dictation starts

## Test plan
- [ ] Test mic mode starts with proper dictation begin sound
- [ ] Test Enter key confirms and saves transcription with confirmation sound  
- [ ] Test Escape key cancels transcription with cancel sound
- [ ] Test clicking outside input area auto-saves transcription
- [ ] Test window focus loss auto-saves transcription
- [ ] Verify no text duplication occurs during transcription
- [ ] Test all exit methods work in both search and prompt modes

🤖 Generated with [Claude Code](https://claude.ai/code)