### PR TITLE
Fix enhance button functionality for prompt editor integration

### DIFF
--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -31,6 +31,11 @@ final class ContentManager {
     // Pending inline rename request for a specific item id
     var pendingRenameItemId: UUID?
     
+    // Prompt editor state tracking for enhanced button integration
+    var promptEditorText: String = ""
+    var isPromptEditorEditing: Bool = false
+    var enhanceButtonClicked: Bool = false // Flag to prevent editor exit on enhance
+    
     // Cache for selected items to avoid repeated full scans and sorts
     @ObservationIgnored private var _selectedCache: [ContentItem] = []
     @ObservationIgnored private var _selectedCacheDirty: Bool = true
@@ -562,12 +567,31 @@ final class ContentManager {
         if item.htmlData != nil { return true }
         return false
     }
+    
+    // MARK: - Prompt Editor State Management
+    
+    func setPromptEditorText(_ text: String) {
+        promptEditorText = text
+    }
+    
+    func setPromptEditorEditing(_ editing: Bool) {
+        isPromptEditorEditing = editing
+        if !editing {
+            // Reset text when exiting edit mode
+            promptEditorText = ""
+        }
+    }
+    
+    func updatePromptEditorText(_ text: String) {
+        promptEditorText = text
+    }
 }
 
 // Global notifications for inline rename coordination
 extension Notification.Name {
     static let CommitActiveRename = Notification.Name("ContentManager.CommitActiveRename")
     static let CancelActiveRename = Notification.Name("ContentManager.CancelActiveRename")
+    static let promptEditorTextUpdated = Notification.Name("ContentManager.promptEditorTextUpdated")
 }
 
 // MARK: - Selected items caching helpers

--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -239,20 +239,46 @@ struct ContentView: View {
                     inputFocused = true
                   }
                 } else if !appState.isEnhancingPrompt {
+                  // Set flag to prevent prompt editor from exiting
+                  contentManager.enhanceButtonClicked = true
+                  
                   // Enhance prompt with AI (only if not already enhancing)
                   Task {
-                    guard !appState.promptText.isEmpty else { return }
+                    let textToEnhance: String
+                    let isEnhancingEditor: Bool
+                    
+                    // Determine what text to enhance
+                    if contentManager.isPromptEditorEditing && !contentManager.promptEditorText.isEmpty {
+                      textToEnhance = contentManager.promptEditorText
+                      isEnhancingEditor = true
+                    } else if !appState.promptText.isEmpty {
+                      textToEnhance = appState.promptText
+                      isEnhancingEditor = false
+                    } else {
+                      contentManager.enhanceButtonClicked = false
+                      return
+                    }
+                    
                     appState.isEnhancingPrompt = true
                     do {
-                      let enhanced = try await PromptEnhancer.shared.enhance(appState.promptText)
-                      // Save original for undo support
-                      appState.originalPromptBeforeEnhancement = appState.promptText
-                      appState.promptText = enhanced
+                      let enhanced = try await PromptEnhancer.shared.enhance(textToEnhance)
+                      if isEnhancingEditor {
+                        // Update prompt editor text
+                        contentManager.updatePromptEditorText(enhanced)
+                        // Also trigger a refresh in the editor by posting a notification
+                        NotificationCenter.default.post(name: .promptEditorTextUpdated, object: enhanced)
+                      } else {
+                        // Save original for undo support
+                        appState.originalPromptBeforeEnhancement = appState.promptText
+                        appState.promptText = enhanced
+                      }
                     } catch {
                       // Handle error - could show alert or tooltip
                       print("Enhancement error: \(error.localizedDescription)")
                     }
                     appState.isEnhancingPrompt = false
+                    // Reset the flag
+                    contentManager.enhanceButtonClicked = false
                   }
                 }
               }) {
@@ -274,7 +300,6 @@ struct ContentView: View {
                 .padding(.all, 2)
               }
               .buttonStyle(PlainButtonStyle())
-              .disabled(appState.promptText.isEmpty && !appState.isSearchMode)
               .help(appState.isSearchMode ? "Exit search mode" : (appState.isEnhancingPrompt ? "Enhancing..." : "Enhance prompt with AI (⌘⇧E)"))
             }
             

--- a/nozzle/Views/Preview/PromptEditorView.swift
+++ b/nozzle/Views/Preview/PromptEditorView.swift
@@ -48,8 +48,6 @@ struct PromptEditorView: View {
     @FocusState private var editorFocused: Bool
     // Grace period after our own save to ignore self-change notifications
     @State private var ignoreChangesUntil: Date? = nil
-    // Enhancement state
-    @State private var isEnhancing: Bool = false
     
     @Environment(ContentManager.self) private var contentManager
     
@@ -79,63 +77,42 @@ struct PromptEditorView: View {
             }
 
             if isEditing {
-                // Editing view with enhance button
-                HStack(alignment: .top, spacing: 0) {
-                    TextEditor(text: $text)
-                        .id(currentItemId)
-                        .font(.body)
-                        .scrollContentBackground(.hidden)
-                        .padding()
-                        .focused($editorFocused)
-                        .onChange(of: editorFocused) { _, focused in
-                            if !focused {
-                                // Save and exit edit mode when focus leaves editor
-                                saveImmediately()
-                                isEditing = false
-                            }
+                // Editing view
+                TextEditor(text: $text)
+                    .id(currentItemId)
+                    .font(.body)
+                    .scrollContentBackground(.hidden)
+                    .padding()
+                    .focused($editorFocused)
+                    .onKeyPress(keys: [.return]) { keyPress in
+                        if keyPress.modifiers.contains(.command) {
+                            // Cmd+Enter: Save and exit edit mode
+                            saveImmediately()
+                            exitEditMode()
+                            return .handled
                         }
-                    
-                    // Enhance button in the top right corner while editing
-                    VStack {
-                        Button(action: {
-                            guard !isEnhancing else { return }
-                            Task {
-                                guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-                                isEnhancing = true
-                                do {
-                                    let enhanced = try await PromptEnhancer.shared.enhance(text)
-                                    text = enhanced
-                                    isDirty = true
-                                    scheduleSave()
-                                } catch {
-                                    // Handle error - could show alert or tooltip
-                                    print("Enhancement error: \(error.localizedDescription)")
-                                }
-                                isEnhancing = false
-                            }
-                        }) {
-                            ZStack {
-                                Image(systemName: "sparkles")
-                                    .font(.system(size: 14))
-                                    .foregroundColor(isEnhancing ? .purple : .secondary)
-                                
-                                if isEnhancing {
-                                    Image(systemName: "sparkles")
-                                        .font(.system(size: 14))
-                                        .foregroundColor(.purple)
-                                        .symbolEffect(.pulse.byLayer, options: .repeating, isActive: isEnhancing)
-                                }
-                            }
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                        .help(isEnhancing ? "Enhancing..." : "Enhance prompt with AI")
-                        .disabled(text.isEmpty)
-                        .padding(.top, 12)
-                        .padding(.trailing, 12)
-                        
-                        Spacer()
+                        // Plain Enter: Allow normal line break behavior in TextEditor
+                        return .ignored
                     }
-                }
+                    .onKeyPress(keys: [.escape]) { _ in
+                        // Escape: Exit edit mode without saving pending changes
+                        isDirty = false
+                        // Reload from disk to revert any unsaved changes
+                        load()
+                        exitEditMode()
+                        return .handled
+                    }
+                    .onChange(of: editorFocused) { _, focused in
+                        if !focused {
+                            // Save and exit edit mode when focus leaves editor
+                            saveImmediately()
+                            exitEditMode()
+                        }
+                    }
+                    .onChange(of: text) { _, newText in
+                        // Update ContentManager with current editing text
+                        contentManager.updatePromptEditorText(newText)
+                    }
             } else {
                 // Read-only preview matching PlainTextPreview style
                 ZStack {
@@ -154,7 +131,7 @@ struct PromptEditorView: View {
                         .fill(Color.clear)
                         .contentShape(Rectangle())
                         .onTapGesture {
-                            isEditing = true
+                            enterEditMode()
                             DispatchQueue.main.async { editorFocused = true }
                         }
                         .allowsHitTesting(true)
@@ -163,13 +140,6 @@ struct PromptEditorView: View {
             }
         }
         .previewSurfaceStyle()
-        // Exit edit mode when pointer leaves the preview pane (user hovers back to list)
-        .onHover { inside in
-            if isEditing && !inside {
-                saveImmediately()
-                isEditing = false
-            }
-        }
             .onAppear {
                 // Initialize tracking for the first item
                 currentItemId = item.id
@@ -197,7 +167,7 @@ struct PromptEditorView: View {
                 currentFileURL = item.fileURL
                 hasExternalChange = false
                 isDirty = false
-                isEditing = false
+                exitEditMode()
                 load()
                 setupPresenter()
             }
@@ -210,7 +180,7 @@ struct PromptEditorView: View {
                 currentFileURL = item.fileURL
                 hasExternalChange = false
                 isDirty = false
-                isEditing = false
+                exitEditMode()
                 load()
                 setupPresenter()
             }
@@ -219,8 +189,38 @@ struct PromptEditorView: View {
                 saveImmediately()
                 removePresenter()
             }
+            .onReceive(NotificationCenter.default.publisher(for: .CommitActiveRename)) { _ in
+                // Commit editing when user clicks outside (reuse existing rename notification system)
+                // Don't exit if enhance button was clicked
+                if isEditing && !contentManager.enhanceButtonClicked {
+                    saveImmediately()
+                    exitEditMode()
+                } else if contentManager.enhanceButtonClicked {
+                    // Reset the flag after handling
+                    contentManager.enhanceButtonClicked = false
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .promptEditorTextUpdated)) { notification in
+                // Update text when enhanced from outside
+                if isEditing, let enhancedText = notification.object as? String {
+                    text = enhancedText
+                    isDirty = true
+                    scheduleSave()
+                }
+            }
             // Guard against rename races: when a global rename commit happens, pause reactions briefly
             // Note: rename commits are coordinated elsewhere; no special pause needed here
+    }
+    
+    private func enterEditMode() {
+        isEditing = true
+        contentManager.setPromptEditorEditing(true)
+        contentManager.setPromptEditorText(text)
+    }
+    
+    private func exitEditMode() {
+        isEditing = false
+        contentManager.setPromptEditorEditing(false)
     }
     
     private func load() {


### PR DESCRIPTION
## Summary
- Fixed enhance button positioning to remain below unified text field only
- Enhanced prompt editor to work seamlessly with main enhance button
- Improved user experience by removing disabled button states and exit conflicts

## Changes Made
- **Removed duplicate enhance button** from PromptEditorView to avoid UI confusion
- **Updated prompt editor exit behavior** to use rename-like keyboard shortcuts (Cmd+Enter, Escape) and click-outside detection
- **Added state coordination** between ContentManager and PromptEditorView for intelligent enhancement
- **Enhanced button logic** now detects and works with both unified text field and active prompt editor
- **Removed disabled state** from enhance button for consistent visual appearance

## Test Plan
- [x] Enhance button works correctly with unified text field (original behavior preserved)  
- [x] Enhance button works when editing text files in prompt editor
- [x] No accidental editor exits when moving mouse to enhance button
- [x] Proper keyboard shortcuts for prompt editor (Cmd+Enter saves, Escape cancels)
- [x] Click-outside behavior works consistently with rename functionality
- [x] Button maintains full opacity regardless of text field state
- [x] Enhanced text appears immediately in correct context (editor or main input)

🤖 Generated with [Claude Code](https://claude.ai/code)