### PR TITLE
Improve image handling and app icon detection for clipboard items

### DIFF
--- a/nozzle.xcodeproj/project.pbxproj
+++ b/nozzle.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		F569FB192E6E1BFA0076D784 /* RenameEventCatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F569FB162E6E1BFA0076D784 /* RenameEventCatcher.swift */; };
 		F569FB1D2E6E87E90076D784 /* PromptEnhancer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F569FB1B2E6E87E90076D784 /* PromptEnhancer.swift */; };
 		F569FB1F2E6E87F50076D784 /* PromptEnhancement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F569FB1E2E6E87F50076D784 /* PromptEnhancement.swift */; };
+		F56E49222E70EB9A003D6538 /* ScreenshotSourceHeuristics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56E49212E70EB9A003D6538 /* ScreenshotSourceHeuristics.swift */; };
 		F57274592E56720D003A9299 /* ContentSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57274582E56720D003A9299 /* ContentSourceType.swift */; };
 		F572745A2E56720D003A9299 /* ContentSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57274572E56720D003A9299 /* ContentSource.swift */; };
 		F572745B2E56720D003A9299 /* ContentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57274562E56720D003A9299 /* ContentItem.swift */; };
@@ -536,6 +537,7 @@
 		F569FB172E6E1BFA0076D784 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		F569FB1B2E6E87E90076D784 /* PromptEnhancer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptEnhancer.swift; sourceTree = "<group>"; };
 		F569FB1E2E6E87F50076D784 /* PromptEnhancement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptEnhancement.swift; sourceTree = "<group>"; };
+		F56E49212E70EB9A003D6538 /* ScreenshotSourceHeuristics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotSourceHeuristics.swift; sourceTree = "<group>"; };
 		F57274562E56720D003A9299 /* ContentItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentItem.swift; sourceTree = "<group>"; };
 		F57274572E56720D003A9299 /* ContentSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSource.swift; sourceTree = "<group>"; };
 		F57274582E56720D003A9299 /* ContentSourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSourceType.swift; sourceTree = "<group>"; };
@@ -824,7 +826,6 @@
 			isa = PBXGroup;
 			children = (
 				F569FB1C2E6E87E90076D784 /* Services */,
-				F569FB1A2E6E87CF0076D784 /* New Group */,
 				F57274722E57C00B003A9299 /* Utilities */,
 				F572746D2E56B882003A9299 /* Filesystem */,
 				2FBB7A252B5FECBB00C65BBE /* Extensions */,
@@ -865,13 +866,6 @@
 			path = nozzle;
 			sourceTree = "<group>";
 		};
-		F569FB1A2E6E87CF0076D784 /* New Group */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = "New Group";
-			sourceTree = "<group>";
-		};
 		F569FB1C2E6E87E90076D784 /* Services */ = {
 			isa = PBXGroup;
 			children = (
@@ -892,6 +886,7 @@
 		F57274722E57C00B003A9299 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				F56E49212E70EB9A003D6538 /* ScreenshotSourceHeuristics.swift */,
 				F569FB162E6E1BFA0076D784 /* RenameEventCatcher.swift */,
 				F569FB172E6E1BFA0076D784 /* WindowAccessor.swift */,
 				F5C1805E2E63E4A5007ED483 /* CombinedContentBuilder.swift */,
@@ -1171,6 +1166,7 @@
 				F57274662E56722D003A9299 /* UniversalItemView.swift in Sources */,
 				DA13D7DC2C1A223E00FA9E23 /* HistoryItemAppEntity.swift in Sources */,
 				F5C180392E622C8B007ED483 /* DictationManager.swift in Sources */,
+				F56E49222E70EB9A003D6538 /* ScreenshotSourceHeuristics.swift in Sources */,
 				DA555F122CF155A8009608BD /* WrappingTextView.swift in Sources */,
 				F5758AFF2E5D176C00FC0F19 /* QuickLookPreview.swift in Sources */,
 				DAC929D7297A0E8B00814F19 /* NSPasteboard.PasteboardType+Types.swift in Sources */,

--- a/nozzle/Clipboard.swift
+++ b/nozzle/Clipboard.swift
@@ -268,6 +268,36 @@ class Clipboard {
       }
     })
 
+    // If clipboard contains a file URL to an image but no image bytes, eagerly ingest the image data now
+    // while any temporary sandbox extension from the pasteboard is still valid. This fixes preview failures
+    // for sources like CleanShot that only provide a file URL.
+    do {
+      let presentTypes = Set(contents.map { NSPasteboard.PasteboardType($0.type) })
+      let hasImageBytes = presentTypes.contains(.tiff) || presentTypes.contains(.png) || presentTypes.contains(.jpeg) || presentTypes.contains(.heic)
+      if !hasImageBytes {
+        // Find first file URL
+        if let fileURLData = contents.first(where: { NSPasteboard.PasteboardType($0.type) == .fileURL })?.value,
+           let url = URL(dataRepresentation: fileURLData, relativeTo: nil, isAbsolute: true) {
+          // Heuristic: if the file looks like an image (by extension), read bytes now
+          let ext = url.pathExtension.lowercased()
+          let isImageExt = ["png", "jpg", "jpeg", "tif", "tiff", "heic"].contains(ext)
+          if isImageExt {
+            if let data = try? Data(contentsOf: url) {
+              let pbType: NSPasteboard.PasteboardType =
+                (ext == "png") ? .png :
+                (ext == "jpg" || ext == "jpeg") ? .jpeg :
+                (ext == "heic") ? .heic :
+                .tiff
+              contents.append(HistoryItemContent(type: pbType.rawValue, value: data))
+            }
+          }
+        }
+      }
+    }
+    // Swallow any errors silently; fallback behavior will still capture the URL
+    catch {
+    }
+
     guard !contents.isEmpty else {
       return
     }

--- a/nozzle/Observables/HistoryItemDecorator.swift
+++ b/nozzle/Observables/HistoryItemDecorator.swift
@@ -3,6 +3,7 @@ import Defaults
 import Foundation
 import Observation
 import Sauce
+import UniformTypeIdentifiers
 
 @Observable @MainActor
 class HistoryItemDecorator: ListItemDecorator {
@@ -62,11 +63,24 @@ class HistoryItemDecorator: ListItemDecorator {
     guard let firstFileURL = item.fileURLs.first else { return nil }
     return FileTypeBadgeCache.shared.icon(forURL: firstFileURL)
   }
+  // Heuristic: treat first file's extension as type; avoid touching the file system when possible
+  private var fileIsImage: Bool {
+    guard let first = item.fileURLs.first else { return false }
+    if let type = UTType(filenameExtension: first.pathExtension) {
+      return type.conforms(to: .image)
+    }
+    return false
+  }
   
   // Protocol conformance
-  var appIcon: ApplicationImage? { 
+  var appIcon: ApplicationImage? {
     if let fileIcon = fileIcon {
-      // For file URLs, show file icon as app icon for proper alignment
+      // For clipboard file URLs: if it is an image, prefer the source application icon
+      // to restore expected behavior for screenshots and copied images.
+      if fileIsImage {
+        return applicationImage
+      }
+      // Non-image files: show file type badge for alignment and quick recognition
       return ApplicationImage(bundleIdentifier: nil, image: fileIcon)
     }
     return applicationImage
@@ -123,12 +137,21 @@ class HistoryItemDecorator: ListItemDecorator {
     synchronizeItemTitle()
     Task {
       // Extract HistoryItem properties on MainActor before passing to actor
-      let (universalClipboard, application) = await MainActor.run {
-        (item.universalClipboard, item.application)
+      let (universalClipboard, application, fileURLs) = await MainActor.run {
+        (item.universalClipboard, item.application, item.fileURLs)
       }
+      // Heuristic override: if the only available hint is Nozzle or nil, infer from file path
+      var effectiveApp = application
+      if let nozzleId = Bundle.main.bundleIdentifier, effectiveApp == nozzleId, let url = fileURLs.first {
+        effectiveApp = ScreenshotSourceHeuristics.guessBundleId(for: url) ?? effectiveApp
+      }
+      if effectiveApp == nil, let url = fileURLs.first {
+        effectiveApp = ScreenshotSourceHeuristics.guessBundleId(for: url)
+      }
+
       self.applicationImage = await ApplicationImageCache.shared.getImage(
         universalClipboard: universalClipboard,
-        application: application
+        application: effectiveApp
       )
     }
     Task { @MainActor in

--- a/nozzle/Observables/UniversalItemDecorator.swift
+++ b/nozzle/Observables/UniversalItemDecorator.swift
@@ -51,14 +51,25 @@ final class UniversalItemDecorator: ListItemDecorator {
     
     // App icon for clipboard items
     var clipboardAppIcon: ApplicationImage? {
-        if _appIcon == nil, base.sourceType == .clipboard, let bundleId = base.applicationBundleId {
-            Task {
-                let appIcon = await ApplicationImageCache.shared.getImage(
-                    universalClipboard: false, 
-                    application: bundleId
-                )
-                await MainActor.run {
-                    _appIcon = appIcon
+        if _appIcon == nil, base.sourceType == .clipboard {
+            // Derive effective bundle identifier, with heuristics for common sources like CleanShot
+            var effectiveBundleId = base.applicationBundleId
+            if let nozzleId = Bundle.main.bundleIdentifier, effectiveBundleId == nozzleId,
+               let url = base.fileURL, let guess = ScreenshotSourceHeuristics.guessBundleId(for: url) {
+                effectiveBundleId = guess
+            }
+            if effectiveBundleId == nil, let url = base.fileURL,
+               let guess = ScreenshotSourceHeuristics.guessBundleId(for: url) {
+                effectiveBundleId = guess
+            }
+
+            if let bundleId = effectiveBundleId {
+                Task {
+                    let appIcon = await ApplicationImageCache.shared.getImage(
+                        universalClipboard: false,
+                        application: bundleId
+                    )
+                    await MainActor.run { self._appIcon = appIcon }
                 }
             }
         }
@@ -66,15 +77,26 @@ final class UniversalItemDecorator: ListItemDecorator {
     }
     
     // Protocol conformance - ListItemDecorator
-    var appIcon: ApplicationImage? { 
-        // For clipboard items with file URLs, prefer file type badge over app icon
-        if base.sourceType == .clipboard, base.fileURL != nil {
-            return typeBadgeImage
-        }
-        // For other clipboard items, prefer app icon over file type badge
+    var appIcon: ApplicationImage? {
+        // Clipboard items
         if base.sourceType == .clipboard {
+            // If this clipboard item represents an image file, prefer the source app icon
+            // to match historical behavior and user expectations. Detect via UTType or filename extension.
+            if let url = base.fileURL {
+                let isImageByUTI = base.isImage
+                let isImageByExt = UTType(filenameExtension: url.pathExtension)?.conforms(to: .image) == true
+                if isImageByUTI || isImageByExt {
+                    return clipboardAppIcon ?? typeBadgeImage
+                }
+            }
+            // For non-image file URLs copied to clipboard, use the file type badge
+            if base.fileURL != nil {
+                return typeBadgeImage
+            }
+            // Plain clipboard items (text, rich text, image data)
             return clipboardAppIcon ?? typeBadgeImage
         }
+        // Non-clipboard sources: show a type badge when available
         return typeBadgeImage
     }
     var image: NSImage? { 

--- a/nozzle/Utilities/FileTypeBadgeCache.swift
+++ b/nozzle/Utilities/FileTypeBadgeCache.swift
@@ -33,20 +33,18 @@ final class FileTypeBadgeCache {
     }
     
     func icon(forURL url: URL) -> NSImage? {
-        // Try to get UTType from URL
+        // Try to get UTType from URL (content-type based badge)
         if let vals = try? url.resourceValues(forKeys: [.contentTypeKey]),
            let type = vals.contentType {
             return icon(for: type)
         }
-        
         // Fall back to extension-based detection
         if let type = UTType(filenameExtension: url.pathExtension) {
             return icon(for: type)
         }
-        
         return nil
     }
-    
+
     func clearCache() {
         cache.removeAll()
     }

--- a/nozzle/Utilities/ScreenshotSourceHeuristics.swift
+++ b/nozzle/Utilities/ScreenshotSourceHeuristics.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+enum ScreenshotSourceHeuristics {
+    /// Best-effort guess of the originating app bundle identifier for a clipboard image URL.
+    /// Uses path fingerprints of popular tools; returns nil if no match.
+    static func guessBundleId(for url: URL) -> String? {
+        let path = url.path.lowercased()
+
+        // CleanShot X
+        if path.contains("/library/application support/cleanshot/") ||
+            path.contains("/cleanshot ") ||
+            path.contains("/cleanshot/") {
+            return "pl.maketheweb.cleanshotx"
+        }
+
+        // Shottr (common paths under Pictures/Shottr or Application Support/Shottr)
+        if path.contains("/pictures/shottr/") ||
+            path.contains("/library/application support/shottr/") ||
+            path.contains("/shottr ") ||
+            path.contains("/shottr/") {
+            return "com.TIGERBEBE.Shottr"
+        }
+
+        // Xnapper (sandbox container path or support dir may contain Xnapper)
+        if path.contains("/xnapper/") ||
+            path.contains("org.xnapper.xnapper") ||
+            path.contains("/library/containers/org.xnapper.xnapper/") ||
+            path.contains("/library/application support/xnapper/") {
+            return "org.xnapper.Xnapper"
+        }
+
+        // Monosnap
+        if path.contains("/monosnap/") || path.contains("com.monosnap.monosnap") {
+            return "com.monosnap.monosnap"
+        }
+
+        // Default: no guess
+        return nil
+    }
+}
+

--- a/nozzle/Views/Preview/PreviewPaneView.swift
+++ b/nozzle/Views/Preview/PreviewPaneView.swift
@@ -10,15 +10,8 @@ struct PreviewPaneView: View {
     var body: some View {
         VStack(spacing: 0) {
             if let clipboardItem = clipboardItem {
-                // Check if clipboard item contains file URLs for QuickLook preview
-                if clipboardItem.hasFileURL, let fileURL = clipboardItem.item.fileURLs.first {
-                    // Use QuickLook for clipboard file URLs
-                    QuickLookPreview(url: fileURL)
-                        .id(fileURL)
-                        .padding()
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else if let image = clipboardItem.previewImage {
-                    // Image preview like pre-August 22nd
+                // Prefer in-memory image bytes for clipboard images to avoid sandbox issues with external URLs
+                if let image = clipboardItem.previewImage {
                     Image(nsImage: image)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
@@ -26,6 +19,12 @@ struct PreviewPaneView: View {
                         .padding()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .previewSurfaceStyle()
+                } else if clipboardItem.hasFileURL, let fileURL = clipboardItem.item.fileURLs.first {
+                    // Non-image clipboard files: use QuickLook
+                    QuickLookPreview(url: fileURL)
+                        .id(fileURL)
+                        .padding()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
                     // Plain text preview for clipboard text (no metadata)
                     PlainTextPreview(


### PR DESCRIPTION
## Summary
- Fixed app icon detection for clipboard items from screenshot tools like CleanShot
- Added eager image data ingestion to handle temporary file URLs properly  
- Improved preview display prioritization for clipboard images
- Added ScreenshotSourceHeuristics utility for identifying screenshot sources

## Test plan
- [x] Test CleanShot screenshot copying shows correct app icon
- [x] Verify image previews work for temporary file URLs
- [x] Check non-image clipboard files still show file type badges
- [x] Ensure existing clipboard functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)