### PR TITLE
Fix folder paste operations and keyboard shortcuts for file sources

### DIFF
--- a/nozzle/Observables/AppState.swift
+++ b/nozzle/Observables/AppState.swift
@@ -431,6 +431,14 @@ class AppState {
     }
     
     let item = mediaItems[index]
+    
+    // Skip folders - their contents are already captured in the selection
+    if item.isFolder {
+      // Move to next item without pasting
+      pasteMediaItems(mediaItems, index: index + 1, promptText: promptText, hasClipboardItems: hasClipboardItems)
+      return
+    }
+    
     // Copy content item to clipboard
     if let imageData = item.imageData, let image = NSImage(data: imageData) {
       let pasteboard = NSPasteboard.general

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -44,6 +44,8 @@ final class ContentManager {
     @ObservationIgnored private var _decoratorCache: [String: [UUID: UniversalItemDecorator]] = [:] // sourceId -> [itemId -> decorator]
     @ObservationIgnored private var _decoratorCacheDirty: Set<String> = [] // sourceIds that need cache refresh
     
+    // (Removed) Aggregated display version tracking; Aggregated now shows only pasteable items
+    
     var selectedItems: [ContentItem] {
         if _selectedCacheDirty {
             _selectedCache = makeSelectedItems()
@@ -197,21 +199,48 @@ final class ContentManager {
         markSelectedDirty()
     }
     
-    func isSelected(_ id: UUID) -> Bool {
-        selectedItemIds.contains(id)
+    func isSelected(_ id: UUID) -> Bool { selectedItemIds.contains(id) }
+
+    // Treat an item as selected if:
+    // - It is explicitly selected, or
+    // - It is a file inside any selected folder (use path prefix check)
+    func isSelected(effectively item: ContentItem) -> Bool {
+        if selectedItemIds.contains(item.id) { return true }
+        guard item.sourceType == .folder, let itemPath = item.fileURL?.path else { return false }
+        // Any selected folder that is an ancestor of this item implies effective selection
+        for fid in selectedItemIds {
+            if let folder = allItems.first(where: { $0.id == fid && $0.isFolder }),
+               let folderPath = folder.fileURL?.path,
+               itemPath.hasPrefix(folderPath.hasSuffix("/") ? folderPath : folderPath + "/") {
+                // Ensure not the folder itself
+                if folder.id != item.id { return true }
+            }
+        }
+        return false
     }
     
     func getFolderSelectionState(_ folderId: UUID) -> FolderSelectionState {
         guard let folderItem = allItems.first(where: { $0.id == folderId }),
               folderItem.isFolder,
               let folderPath = folderItem.fileURL?.path else { return .none }
-        
+
         // Get all visible children of this folder
         let children = allItems.filter { $0.parentPath == folderPath }
-        
-        // If folder is collapsed (no visible children), check if folder itself is selected
+
+        // If folder is collapsed (no visible children), infer state from real descendants on disk
         if children.isEmpty {
-            return selectedItemIds.contains(folderId) ? .all : .none
+            // If the folder itself is selected, treat as all (effective select)
+            if selectedItemIds.contains(folderId) { return .all }
+            // Otherwise, compute based on how many descendants are selected
+            let urls = enumerateDescendantFiles(at: URL(fileURLWithPath: folderPath))
+            guard !urls.isEmpty else { return .none }
+            let selectedCount = urls.reduce(0) { acc, url in
+                let id = stableUUID(for: url)
+                return acc + (selectedItemIds.contains(id) ? 1 : 0)
+            }
+            if selectedCount == 0 { return .none }
+            if selectedCount == urls.count { return .all }
+            return .partial
         }
         
         // For expanded folders, calculate based on children selection
@@ -428,24 +457,33 @@ final class ContentManager {
         decorator.updateBase(originalItem)
     }
     
-    // Get cached decorators for selected context items
+    // Get cached decorators for selected context items (Aggregated shows only pasteable files)
     var selectedContextDecorators: [UniversalItemDecorator] {
-        selectedContextItems.compactMap { item in
+        let displayItems = filteredForAggregatedDisplay(selectedContextItems)
+        return displayItems.compactMap { item in
             // Ensure the source decorators are loaded first
             _ = getDecorators(for: item.sourceId)
-            // Find the decorator from the appropriate source cache
-            return _decoratorCache[item.sourceId]?[item.id]
+            // Prefer cached decorator; fall back to ad-hoc for ephemeral items
+            return _decoratorCache[item.sourceId]?[item.id] ?? UniversalItemDecorator(item)
         }
     }
     
-    // Get cached decorators for selected example items  
+    // Get cached decorators for selected example items (Aggregated shows only pasteable files)
     var selectedExampleDecorators: [UniversalItemDecorator] {
-        selectedExampleItems.compactMap { item in
+        let displayItems = filteredForAggregatedDisplay(selectedExampleItems)
+        return displayItems.compactMap { item in
             // Ensure the source decorators are loaded first
             _ = getDecorators(for: item.sourceId)
-            // Find the decorator from the appropriate source cache
-            return _decoratorCache[item.sourceId]?[item.id]
+            // Prefer cached decorator; fall back to ad-hoc for ephemeral items
+            return _decoratorCache[item.sourceId]?[item.id] ?? UniversalItemDecorator(item)
         }
+    }
+
+    // In Aggregated tab, show only pasteable leaf items (no folder rows)
+    private func filteredForAggregatedDisplay(_ items: [ContentItem]) -> [ContentItem] {
+        guard activeSourceId == "aggregated" else { return items }
+        // Drop folders; keep everything else (files, clipboard entries, images)
+        return items.filter { !$0.isFolder }
     }
     
     // Search
@@ -529,7 +567,7 @@ final class ContentManager {
         return false
     }
     
-    private func stableUUID(for url: URL) -> UUID {
+    func stableUUID(for url: URL) -> UUID {
         let snap = FileIdentity.snapshot(for: url)
         return FileSystemSource.makeStableUUID(identity: snap.identity, fallbackPath: url.absoluteString)
     }
@@ -602,18 +640,89 @@ extension ContentManager {
     
     private func makeSelectedItems() -> [ContentItem] {
         let items = allItems
-        guard !selectedItemIds.isEmpty, !items.isEmpty else { return [] }
-        
+        guard !selectedItemIds.isEmpty else { return [] }
+
+        // For folder sources, we need to handle collapsed folders with selected children
+        var hiddenSelectedItems: [ContentItem] = []
+        // For selected folders, we also include all descendant files for paste/aggregated view
+        var expandedFolderDescendants: [UUID: [ContentItem]] = [:] // folderId -> descendants
+
+        // Check each source for selected items that might be hidden
+        for sourceId in orderedSourceIds {
+            guard let source = sources[sourceId] as? FileSystemSource else { continue }
+            // Get all selected IDs that aren't visible in current items
+            let visibleIds = Set(items.map { $0.id })
+            let hiddenSelectedIds = selectedItemIds.subtracting(visibleIds)
+
+            if !hiddenSelectedIds.isEmpty {
+                // Scan the filesystem to find these hidden selected items (both files and folders)
+                let foundItems = source.findItemsById(hiddenSelectedIds)
+                hiddenSelectedItems.append(contentsOf: foundItems)
+            }
+
+            // For any selected folder (visible or hidden), gather all descendant files so they
+            // participate in aggregated view and paste operations even when collapsed
+            let allKnownItems = items + hiddenSelectedItems
+            for fid in selectedItemIds {
+                if expandedFolderDescendants[fid] != nil { continue }
+                guard let folderItem = allKnownItems.first(where: { $0.id == fid && $0.isFolder }) else { continue }
+                guard let baseURL = folderItem.fileURL else { continue }
+                // Enumerate all descendant files
+                let urls = enumerateDescendantFiles(at: baseURL)
+                if urls.isEmpty { continue }
+                var desc: [ContentItem] = []
+                desc.reserveCapacity(urls.count)
+                for url in urls {
+                    do {
+                        let vals = try url.resourceValues(forKeys: [.isDirectoryKey, .contentTypeKey, .contentModificationDateKey, .fileSizeKey])
+                        if vals.isDirectory == true { continue }
+                        let snap = FileIdentity.snapshot(for: url)
+                        let type = FileSystemSource.resolvedType(for: url)
+                        let cid = FileSystemSource.makeStableUUID(identity: snap.identity, fallbackPath: url.absoluteString)
+                        // Compute depth relative to the base folder for nicer indentation in Aggregated tab
+                        // In Aggregated view we don't show folders, so present files as flat items
+                        let item = ContentItem(
+                            id: cid,
+                            title: url.lastPathComponent,
+                            timestamp: vals.contentModificationDate ?? Date(),
+                            sourceType: .folder,
+                            sourceId: source.id,
+                            fileURL: url,
+                            imageData: nil,
+                            rtfData: nil,
+                            htmlData: nil,
+                            plainText: nil,
+                            fileIdentity: snap.identity,
+                            uniformTypeIdentifier: type?.identifier,
+                            fileSize: vals.fileSize.flatMap(Int64.init),
+                            isFolder: false,
+                            depth: 0,
+                            parentPath: nil,
+                            isSelected: true,
+                            isVisible: true
+                        )
+                        desc.append(item)
+                    } catch {
+                        continue
+                    }
+                }
+                if !desc.isEmpty { expandedFolderDescendants[fid] = desc }
+            }
+        }
+
+        // Combine visible and hidden selected items
+        let allItemsIncludingHidden = items + hiddenSelectedItems
+
         // Index folders by path for fast parent lookup
         var folderByPath: [String: ContentItem] = [:]
-        folderByPath.reserveCapacity(items.count)
-        for item in items where item.isFolder {
+        folderByPath.reserveCapacity(allItemsIncludingHidden.count)
+        for item in allItemsIncludingHidden where item.isFolder {
             if let path = item.fileURL?.path { folderByPath[path] = item }
         }
         
         // Determine which parent folders need to be included due to selected children
         var neededParentIds: Set<UUID> = []
-        for item in items {
+        for item in allItemsIncludingHidden {
             guard selectedItemIds.contains(item.id) else { continue }
             if let parentPath = item.parentPath, let parent = folderByPath[parentPath] {
                 if !selectedItemIds.contains(parent.id) {
@@ -622,22 +731,22 @@ extension ContentManager {
             }
         }
         
-        // Build result with better hierarchical grouping
+        // Build result with hierarchical grouping and expanded descendants for selected folders
         var result: [ContentItem] = []
         result.reserveCapacity(selectedItemIds.count + neededParentIds.count)
         var seen: Set<UUID> = []
-        
-        // Process items in hierarchical order: folders followed immediately by their children
-        for item in items {
+
+        // Process items in hierarchical order: folders followed by their children
+        for item in allItemsIncludingHidden {
             // Add folders (both needed parents and explicitly selected)
             if item.isFolder && (neededParentIds.contains(item.id) || selectedItemIds.contains(item.id)) {
                 if !seen.contains(item.id) {
                     result.append(item)
                     seen.insert(item.id)
-                    
+
                     // Immediately add children of this folder that are selected
                     let folderPath = item.fileURL?.path
-                    for childItem in items {
+                    for childItem in allItemsIncludingHidden {
                         if selectedItemIds.contains(childItem.id) && 
                            !seen.contains(childItem.id) && 
                            childItem.parentPath == folderPath {
@@ -645,12 +754,20 @@ extension ContentManager {
                             seen.insert(childItem.id)
                         }
                     }
+
+                    // If the folder itself is selected, also append all descendant files (collapsed case)
+                    if selectedItemIds.contains(item.id), let desc = expandedFolderDescendants[item.id] {
+                        for d in desc where !seen.contains(d.id) {
+                            result.append(d)
+                            seen.insert(d.id)
+                        }
+                    }
                 }
             }
         }
         
         // Add any remaining selected items that don't have a parent (e.g., clipboard items)
-        for item in items {
+        for item in allItemsIncludingHidden {
             if selectedItemIds.contains(item.id) && !seen.contains(item.id) {
                 result.append(item)
                 seen.insert(item.id)

--- a/nozzle/Observables/FileSystemSource.swift
+++ b/nozzle/Observables/FileSystemSource.swift
@@ -404,6 +404,67 @@ final class FileSystemSource: ContentSource {
         }
     }
     
+    // Find items by their IDs, even if they're not currently visible (collapsed folders)
+    func findItemsById(_ ids: Set<UUID>) -> [ContentItem] {
+        guard !ids.isEmpty else { return [] }
+        
+        var foundItems: [ContentItem] = []
+        let fm = FileManager.default
+        
+        // Recursively scan the folder to find matching items
+        if let enumerator = fm.enumerator(
+            at: folderURL,
+            includingPropertiesForKeys: [.isDirectoryKey, .contentTypeKey, .contentModificationDateKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) {
+            for case let url as URL in enumerator {
+                // Generate stable UUID for this URL
+                let itemId = Self.makeStableUUID(
+                    identity: FileIdentity.snapshot(for: url).identity,
+                    fallbackPath: url.absoluteString
+                )
+                
+                // Check if this ID is one we're looking for
+                if ids.contains(itemId) {
+                    do {
+                        let vals = try url.resourceValues(forKeys: [.isDirectoryKey, .contentTypeKey, .contentModificationDateKey, .fileSizeKey])
+                        
+                        // Calculate depth and parent path
+                        let relativePath = url.path.replacingOccurrences(of: folderURL.path + "/", with: "")
+                        let depth = relativePath.components(separatedBy: "/").count
+                        let parentPath = url.deletingLastPathComponent().path
+                        
+                        let contentItem = ContentItem(
+                            id: itemId,
+                            title: url.lastPathComponent,
+                            timestamp: vals.contentModificationDate ?? Date(),
+                            sourceType: .folder,
+                            sourceId: self.id,
+                            fileURL: url,
+                            uniformTypeIdentifier: vals.contentType?.identifier,
+                            fileSize: Int64(vals.fileSize ?? 0),
+                            isFolder: vals.isDirectory == true,
+                            depth: depth,
+                            parentPath: parentPath == folderURL.path ? nil : parentPath,
+                            isSelected: true // These are selected items
+                        )
+                        
+                        foundItems.append(contentItem)
+                        
+                        // Stop early if we've found all items
+                        if foundItems.count == ids.count {
+                            break
+                        }
+                    } catch {
+                        continue
+                    }
+                }
+            }
+        }
+        
+        return foundItems
+    }
+    
     // MARK: - Folder expansion methods
     
     func toggleFolderExpansion(at path: String) async {

--- a/nozzle/Observables/UniversalItemDecorator.swift
+++ b/nozzle/Observables/UniversalItemDecorator.swift
@@ -33,7 +33,7 @@ final class UniversalItemDecorator: ListItemDecorator {
         return base.title
     }
     var isSelected: Bool {
-        ContentManager.shared.isSelected(id)
+        ContentManager.shared.isSelected(effectively: base)
     }
     var isExample: Bool {
         ContentManager.shared.isExample(id)

--- a/nozzle/Views/FolderTreeItemView.swift
+++ b/nozzle/Views/FolderTreeItemView.swift
@@ -166,9 +166,11 @@ struct FolderTreeItemView: View {
     private func toggleExpansion() {
         guard let fileSystemSource = contentManager.sources[item.sourceId] as? FileSystemSource,
               let folderPath = item.base.fileURL?.path else { return }
-        
+
         Task {
             await fileSystemSource.toggleFolderExpansion(at: folderPath)
+            // Nudge dependent views to refresh
+            ContentManager.shared.markSelectedDirty()
         }
     }
 }

--- a/nozzle/Views/KeyHandlingView.swift
+++ b/nozzle/Views/KeyHandlingView.swift
@@ -47,23 +47,43 @@ struct KeyHandlingView<Content: View>: View {
             }
             // Plain Enter - immediately paste current item
             if let item = appState.history.selectedItem {
+              // Clipboard item
               appState.popup.close()
               Clipboard.shared.copy(item.item)
               Clipboard.shared.paste()
+            } else if let focusedItem = contentManager.focusedContentItem {
+              // File source item - skip folders
+              appState.popup.close()
+              if let fileURL = focusedItem.fileURL, !focusedItem.isFolder {
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.writeObjects([fileURL as NSURL])
+                Clipboard.shared.paste()
+              }
             }
             return .handled
           } else if modifierFlags == [.command, .shift] {
             // Command-Shift-Enter - paste just the focused item
             if let item = appState.history.selectedItem {
+              // Clipboard item
               appState.popup.close()
               Clipboard.shared.copy(item.item)
               Clipboard.shared.paste()
+            } else if let focusedItem = contentManager.focusedContentItem {
+              // File source item - skip folders
+              appState.popup.close()
+              if let fileURL = focusedItem.fileURL, !focusedItem.isFolder {
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.writeObjects([fileURL as NSURL])
+                Clipboard.shared.paste()
+              }
             }
             return .handled
           } else if modifierFlags == .command {
             // Command-Enter (combined paste)
             // Only handle if we have multiple selections or prompt text
-            if !appState.history.selectedItems.isEmpty || !appState.promptText.isEmpty {
+            if !contentManager.selectedItems.isEmpty || !appState.promptText.isEmpty {
               appState.performCombinedPaste()
               return .handled
             }

--- a/nozzle/Views/UniversalItemView.swift
+++ b/nozzle/Views/UniversalItemView.swift
@@ -94,10 +94,10 @@ struct UniversalItemView: View {
             } else {
                 // Use regular file view with indentation
                 HStack(spacing: 0) {
-                    // Indentation for depth - files align with folder content 
-                    if item.base.depth > 0 {
+                    // Indentation for depth (skip in Aggregated view — flat list of pasteable items)
+                    if item.base.depth > 0 && contentManager.activeSourceId != "aggregated" {
                         Spacer()
-                            .frame(width: CGFloat(item.base.depth) * 24.0)  // Increased from 20 to 24 for more child indentation
+                            .frame(width: CGFloat(item.base.depth) * 24.0)
                     }
                     
                     ListItemView(


### PR DESCRIPTION
## Summary
- Fixed folder pasting issues where folders were incorrectly pasted as files in multi-paste operations
- Fixed keyboard shortcuts (Enter, Cmd+Enter, Cmd+Shift+Enter) to work properly with file selections
- Fixed collapsed folder selections to include their contents even when not visible in the UI

## Changes
- **Skip folders in multi-paste**: Folders are now skipped during paste operations since their contents are already captured in the selection
- **Fix keyboard shortcuts for files**: Command+Enter now works with file selections (no prompt required), and plain Enter/Command+Shift+Enter properly paste single files from file sources
- **Handle collapsed folders**: Enhanced selectedItems computation to include items from collapsed folders that have partial or full selection
- **Add filesystem scanning**: Added `findItemsById` method to locate selected items that are hidden in collapsed folders
- **Improve aggregated view**: Aggregated tab now shows only pasteable files (no folder rows)

## Test plan
- [ ] Select files in a folder source and press Cmd+Enter - files should paste
- [ ] Select a single file and press Enter - file should paste immediately
- [ ] Select a folder (collapsed) with some items selected inside - those items should paste
- [ ] Mix selections across expanded and collapsed folders - all selected items should paste
- [ ] Verify folder rows don't appear in the aggregated "#" tab view

🤖 Generated with [Claude Code](https://claude.ai/code)