### PR TITLE
Add keyboard shortcuts for tab navigation

### DIFF
--- a/nozzle/KeyChord.swift
+++ b/nozzle/KeyChord.swift
@@ -49,6 +49,8 @@ enum KeyChord: CaseIterable {
   case togglePromptMode
   case toggleDictation
   case toggleSelection
+  case previousTab
+  case nextTab
   case previousTabPage
   case nextTabPage
   case unknown
@@ -132,8 +134,12 @@ enum KeyChord: CaseIterable {
     case (.tab, []):
       self = .toggleSelection
     case (.leftBracket, [.command]):
-      self = .previousTabPage
+      self = .previousTab
     case (.rightBracket, [.command]):
+      self = .nextTab
+    case (.leftBracket, [.command, .shift]):
+      self = .previousTabPage
+    case (.rightBracket, [.command, .shift]):
       self = .nextTabPage
     case (_, _) where !modifierFlags.isDisjoint(with: [.command, .control, .option]):
       self = .ignored

--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -81,7 +81,65 @@ struct ContentView: View {
         searchQuery: $appState.history.searchQuery,
         searchFocused: $inputFocused,
         currentTabPage: $currentTabPage,
-        totalPages: totalPages
+        totalPages: totalPages,
+        onPreviousTab: {
+          let ids = ["aggregated"] + allTabs.map { $0.id }
+          let currentId = ids.contains(selectedTab) ? selectedTab : (ids.contains(contentManager.activeSourceId) ? contentManager.activeSourceId : "aggregated")
+          guard let idx = ids.firstIndex(of: currentId) else { return }
+          let newIdx = (idx - 1 + ids.count) % ids.count
+          let newId = ids[newIdx]
+          selectedTab = newId
+          contentManager.activeSourceId = newId
+          if let fileSource = contentManager.sources[newId] as? FileSystemSource {
+            Task { await fileSource.refreshIfNeeded() }
+          }
+          if newId != "aggregated" {
+            if let tabIndex = allTabs.firstIndex(where: { $0.id == newId }) {
+              // Find page containing tabIndex using pageBreaks
+              var targetPage = 0
+              for i in 0..<pageBreaks.count {
+                let start = pageBreaks[i]
+                let end = (i + 1 < pageBreaks.count) ? pageBreaks[i + 1] : allTabs.count
+                if tabIndex >= start && tabIndex < end {
+                  targetPage = i
+                  break
+                }
+              }
+              if targetPage != currentTabPage {
+                withAnimation(.easeInOut(duration: 0.2)) { currentTabPage = targetPage }
+              }
+            }
+          }
+        },
+        onNextTab: {
+          let ids = ["aggregated"] + allTabs.map { $0.id }
+          let currentId = ids.contains(selectedTab) ? selectedTab : (ids.contains(contentManager.activeSourceId) ? contentManager.activeSourceId : "aggregated")
+          guard let idx = ids.firstIndex(of: currentId) else { return }
+          let newIdx = (idx + 1) % ids.count
+          let newId = ids[newIdx]
+          selectedTab = newId
+          contentManager.activeSourceId = newId
+          if let fileSource = contentManager.sources[newId] as? FileSystemSource {
+            Task { await fileSource.refreshIfNeeded() }
+          }
+          if newId != "aggregated" {
+            if let tabIndex = allTabs.firstIndex(where: { $0.id == newId }) {
+              // Find page containing tabIndex using pageBreaks
+              var targetPage = 0
+              for i in 0..<pageBreaks.count {
+                let start = pageBreaks[i]
+                let end = (i + 1 < pageBreaks.count) ? pageBreaks[i + 1] : allTabs.count
+                if tabIndex >= start && tabIndex < end {
+                  targetPage = i
+                  break
+                }
+              }
+              if targetPage != currentTabPage {
+                withAnimation(.easeInOut(duration: 0.2)) { currentTabPage = targetPage }
+              }
+            }
+          }
+        }
       ) {
         VStack(spacing: 0) {
           // Header: chips (always show when present), input field, and controls with tabs

--- a/nozzle/Views/KeyHandlingView.swift
+++ b/nozzle/Views/KeyHandlingView.swift
@@ -13,6 +13,8 @@ struct KeyHandlingView<Content: View>: View {
   @FocusState.Binding var searchFocused: Bool
   @Binding var currentTabPage: Int
   let totalPages: Int
+  let onPreviousTab: () -> Void
+  let onNextTab: () -> Void
   @ViewBuilder let content: () -> Content
 
   @Environment(AppState.self) private var appState
@@ -308,8 +310,14 @@ struct KeyHandlingView<Content: View>: View {
             appState.updateFooterItemVisibility()
           }
           return .handled
+        case .previousTab:
+          onPreviousTab()
+          return .handled
+        case .nextTab:
+          onNextTab()
+          return .handled
         case .previousTabPage:
-          // Cmd+[ - navigate to previous tab page
+          // Cmd+Shift+[ - navigate to previous tab page
           if currentTabPage > 0 {
             withAnimation(.easeInOut(duration: 0.2)) {
               currentTabPage -= 1
@@ -317,7 +325,7 @@ struct KeyHandlingView<Content: View>: View {
           }
           return .handled
         case .nextTabPage:
-          // Cmd+] - navigate to next tab page
+          // Cmd+Shift+] - navigate to next tab page
           if currentTabPage < totalPages - 1 {
             withAnimation(.easeInOut(duration: 0.2)) {
               currentTabPage += 1


### PR DESCRIPTION
## Summary
- Add Cmd+[ and Cmd+] for navigating between tabs (sources)
- Move existing tab page navigation to Cmd+Shift+[ and Cmd+Shift+]
- Implement seamless tab switching with automatic page discovery
- Update KeyChord enum with new previousTab/nextTab keyboard shortcuts

## Changes
- **KeyChord.swift**: Added `previousTab` and `nextTab` cases, updated key mappings
- **ContentView.swift**: Added tab navigation callbacks with page switching logic
- **KeyHandlingView.swift**: Implemented keyboard handlers for new tab shortcuts

## Test plan
- [ ] Verify Cmd+[ cycles through tabs in reverse order
- [ ] Verify Cmd+] cycles through tabs in forward order  
- [ ] Verify tab page automatically switches when navigating to tabs on different pages
- [ ] Verify existing Cmd+Shift+[ and Cmd+Shift+] still work for page navigation
- [ ] Test with multiple folder sources and aggregated tab

🤖 Generated with [Claude Code](https://claude.ai/code)