### PR TITLE
Fix click area detection for example toggle in file tabs

### DIFF
--- a/nozzle/Views/FolderTreeItemView.swift
+++ b/nozzle/Views/FolderTreeItemView.swift
@@ -6,6 +6,7 @@ struct FolderTreeItemView: View {
     @Bindable var item: UniversalItemDecorator
     @Environment(AppState.self) private var appState
     @Environment(ContentManager.self) private var contentManager
+    @State private var itemFrameWidth: CGFloat = 0
     
     private var isExpanded: Bool {
         if let fileSystemSource = contentManager.sources[item.sourceId] as? FileSystemSource,
@@ -78,7 +79,7 @@ struct FolderTreeItemView: View {
             .onTapGesture { location in
                 // Handle folder selection and focus
                 let copyAreaThreshold: CGFloat = 42
-                let frameWidth: CGFloat = 300
+                let frameWidth = itemFrameWidth > 0 ? itemFrameWidth : 300  // fallback width
                 
                 if location.x > (frameWidth - copyAreaThreshold) {
                     if !contentManager.isSelected(item.id) {
@@ -107,6 +108,17 @@ struct FolderTreeItemView: View {
                     FolderTreeItemView.previewHoverThrottler.cancel()
                 }
             }
+            .background(
+                GeometryReader { geometry in
+                    Color.clear
+                        .onAppear {
+                            itemFrameWidth = geometry.size.width
+                        }
+                        .onChange(of: geometry.size) { _, newSize in
+                            itemFrameWidth = newSize.width
+                        }
+                }
+            )
             .contextMenu {
                 if let url = item.base.fileURL {
                     Button("Copy Path") {

--- a/nozzle/Views/HistoryItemView.swift
+++ b/nozzle/Views/HistoryItemView.swift
@@ -51,7 +51,7 @@ struct HistoryItemView: View {
       shortcuts: item.shortcuts,
       isSelected: item.isSelected,
       selectionSymbol: (contentManager.isExample(item.id) ? "pencil.circle.fill" : "checkmark.circle.fill"),
-      selectionSymbolColor: (contentManager.isExample(item.id) ? .yellow : .white),
+      selectionSymbolColor: .white,
       selectionBackgroundColor: (contentManager.isExample(item.id) ? .yellow : nil),
       onCopyAction: copyItemToClipboard
     ) {

--- a/nozzle/Views/UniversalItemView.swift
+++ b/nozzle/Views/UniversalItemView.swift
@@ -84,6 +84,7 @@ struct UniversalItemView: View {
     @Environment(ContentManager.self) private var contentManager
     @State private var isRenaming: Bool = false
     @State private var editingName: String = ""
+    @State private var itemFrameWidth: CGFloat = 0
     @FocusState private var renameFocused: Bool
     
     var body: some View {
@@ -120,9 +121,9 @@ struct UniversalItemView: View {
                             NotificationCenter.default.post(name: .CommitActiveRename, object: nil)
                             return
                         }
-                        // Check if click is in the checkbox/selection area (right 60 pixels)
+                        // Check if click is in the checkbox/selection area (right 42 pixels)
                         let selectionAreaThreshold: CGFloat = 42
-                        let frameWidth: CGFloat = 300  // Approximate width
+                        let frameWidth = itemFrameWidth > 0 ? itemFrameWidth : 300  // fallback width
                         
                         if location.x > (frameWidth - selectionAreaThreshold) && item.isSelected {
                             // Toggle example state when clicking the selected checkmark area
@@ -174,6 +175,17 @@ struct UniversalItemView: View {
                 }
             }
         }
+        .background(
+            GeometryReader { geometry in
+                Color.clear
+                    .onAppear {
+                        itemFrameWidth = geometry.size.width
+                    }
+                    .onChange(of: geometry.size) { _, newSize in
+                        itemFrameWidth = newSize.width
+                    }
+            }
+        )
         .contextMenu {
             if item.base.sourceId == "prompts", let url = item.base.fileURL {
                 Button("New") {

--- a/nozzle/Views/UniversalItemView.swift
+++ b/nozzle/Views/UniversalItemView.swift
@@ -109,7 +109,7 @@ struct UniversalItemView: View {
                         shortcuts: [],                       // no numbered shortcuts for file sources in Phase 1
                         isSelected: item.isSelected,
                         selectionSymbol: (item.isExample ? "pencil.circle.fill" : "checkmark.circle.fill"),
-                        selectionSymbolColor: (item.isExample ? .yellow : .white),
+                        selectionSymbolColor: .white,
                         selectionBackgroundColor: (item.isExample ? .yellow : nil),
                         onCopyAction: { item.copyToClipboard() }
                     ) { titleView() }


### PR DESCRIPTION
## Summary
• Fixed click area detection issue where clicking on empty space in file tab items incorrectly triggered example toggle
• Now only clicks in the actual checkbox area (rightmost 42 pixels) will toggle example state
• Matches the correct behavior already present in clipboard tabs

## Problem
File tab items used a hardcoded 300px width approximation for click detection, causing clicks far from the actual checkbox icon to trigger example toggles. This was especially problematic when trying to deselect items by clicking on empty space.

## Solution
- **UniversalItemView**: Added GeometryReader to capture actual frame width instead of hardcoded 300px
- **FolderTreeItemView**: Added GeometryReader to capture actual frame width instead of hardcoded 300px
- Both views now use real measurements for precise click area detection

## Technical Details
- Added `@State private var itemFrameWidth: CGFloat = 0` to track actual width
- Added `.background(GeometryReader {...})` to measure frame dynamically  
- Updated click detection to use `itemFrameWidth > 0 ? itemFrameWidth : 300` with fallback
- Only clicks in rightmost 42 pixels (where checkbox icon actually appears) trigger example toggle

## Test plan
- [ ] Build and run the application
- [ ] In file tabs, select an item (shows checkbox icon)
- [ ] Click precisely on the checkbox area → should toggle example state ✅
- [ ] Click on empty space within the item row → should deselect item (not toggle example) ✅
- [ ] Verify behavior now matches clipboard tabs exactly
- [ ] Test with both file items and folder items

🤖 Generated with [Claude Code](https://claude.ai/code)