### PR TITLE
Improve keyboard shortcuts for dictation and enhance prompt functionality

### DIFF
--- a/nozzle/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
+++ b/nozzle/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
@@ -7,5 +7,6 @@ extension KeyboardShortcuts.Name {
   static let togglePreview = Self("togglePreview", default: Shortcut(.space, modifiers: [.control]))
   static let clearSelection = Self("clearSelection", default: Shortcut(.delete, modifiers: [.command]))
   static let togglePromptMode = Self("togglePromptMode", default: Shortcut(.f, modifiers: [.command]))
-  static let toggleDictation = Self("toggleDictation", default: Shortcut(.d, modifiers: [.control]))
+  static let toggleDictation = Self("toggleDictation", default: Shortcut(.d, modifiers: [.option]))
+  static let enhancePrompt = Self("enhancePrompt", default: Shortcut(.e, modifiers: [.command]))
 }

--- a/nozzle/KeyChord.swift
+++ b/nozzle/KeyChord.swift
@@ -29,13 +29,15 @@ enum KeyChord: CaseIterable {
   static var toggleDictationKey: Key? { Sauce.shared.key(shortcut: .toggleDictation) }
   static var toggleDictationModifiers: NSEvent.ModifierFlags? { KeyboardShortcuts.Shortcut(name: .toggleDictation)?.modifiers }
 
+  static var enhancePromptKey: Key? { Sauce.shared.key(shortcut: .enhancePrompt) }
+  static var enhancePromptModifiers: NSEvent.ModifierFlags? { KeyboardShortcuts.Shortcut(name: .enhancePrompt)?.modifiers }
+
   case clearHistory
   case clearHistoryAll
   case clearSearch
   case clearSelection
   case deleteCurrentItem
   case deleteOneCharFromSearch
-  case deleteLastWordFromSearch
   case ignored
   case moveToNext
   case moveToLast
@@ -48,6 +50,7 @@ enum KeyChord: CaseIterable {
   case togglePreview
   case togglePromptMode
   case toggleDictation
+  case enhancePrompt
   case toggleSelection
   case previousTab
   case nextTab
@@ -94,8 +97,6 @@ enum KeyChord: CaseIterable {
       self = .deleteCurrentItem
     case (.h, [.control]):
       self = .deleteOneCharFromSearch
-    case (.w, [.control]):
-      self = .deleteLastWordFromSearch
     case (.downArrow, []),
          (.downArrow, [.shift]),
          (.n, [.control]),
@@ -131,6 +132,8 @@ enum KeyChord: CaseIterable {
       self = .togglePromptMode
     case (KeyChord.toggleDictationKey, KeyChord.toggleDictationModifiers):
       self = .toggleDictation
+    case (KeyChord.enhancePromptKey, KeyChord.enhancePromptModifiers):
+      self = .enhancePrompt
     case (.tab, []):
       self = .toggleSelection
     case (.leftBracket, [.command]):

--- a/nozzle/Observables/AppState.swift
+++ b/nozzle/Observables/AppState.swift
@@ -523,5 +523,51 @@ class AppState {
       promptChips = updated
     }
   }
+  
+  // Enhance the current prompt using AI
+  func performEnhancePrompt() {
+    guard !isEnhancingPrompt else { return }
+    
+    // Set flag to prevent prompt editor from exiting if applicable
+    ContentManager.shared.enhanceButtonClicked = true
+    
+    Task { @MainActor in
+      let textToEnhance: String
+      let isEnhancingEditor: Bool
+      
+      // Determine what text to enhance
+      if ContentManager.shared.isPromptEditorEditing && !ContentManager.shared.promptEditorText.isEmpty {
+        textToEnhance = ContentManager.shared.promptEditorText
+        isEnhancingEditor = true
+      } else if !promptText.isEmpty {
+        textToEnhance = promptText
+        isEnhancingEditor = false
+      } else {
+        ContentManager.shared.enhanceButtonClicked = false
+        return
+      }
+      
+      isEnhancingPrompt = true
+      do {
+        let enhanced = try await PromptEnhancer.shared.enhance(textToEnhance)
+        if isEnhancingEditor {
+          // Update prompt editor text
+          ContentManager.shared.updatePromptEditorText(enhanced)
+          // Also trigger a refresh in the editor by posting a notification
+          NotificationCenter.default.post(name: .promptEditorTextUpdated, object: enhanced)
+        } else {
+          // Save original for undo support
+          originalPromptBeforeEnhancement = promptText
+          promptText = enhanced
+        }
+      } catch {
+        // Handle error - could show alert or tooltip
+        print("Enhancement error: \(error.localizedDescription)")
+      }
+      isEnhancingPrompt = false
+      // Reset the flag
+      ContentManager.shared.enhanceButtonClicked = false
+    }
+  }
 
 }

--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -284,7 +284,7 @@ struct ContentView: View {
                   .padding(.all, 2)
               }
               .buttonStyle(PlainButtonStyle())
-              .help(appState.isSearchMode ? "Exit search mode" : (dictationManager.isRecording ? "Stop dictation (fn)" : "Start dictation (fn)"))
+              .help(appState.isSearchMode ? "Exit search mode" : (dictationManager.isRecording ? "Stop dictation (⌥D)" : "Start dictation (⌥D)"))
               
               
               // Enhance prompt button
@@ -296,48 +296,9 @@ struct ContentView: View {
                     try? await Task.sleep(for: .milliseconds(50))
                     inputFocused = true
                   }
-                } else if !appState.isEnhancingPrompt {
-                  // Set flag to prevent prompt editor from exiting
-                  contentManager.enhanceButtonClicked = true
-                  
-                  // Enhance prompt with AI (only if not already enhancing)
-                  Task {
-                    let textToEnhance: String
-                    let isEnhancingEditor: Bool
-                    
-                    // Determine what text to enhance
-                    if contentManager.isPromptEditorEditing && !contentManager.promptEditorText.isEmpty {
-                      textToEnhance = contentManager.promptEditorText
-                      isEnhancingEditor = true
-                    } else if !appState.promptText.isEmpty {
-                      textToEnhance = appState.promptText
-                      isEnhancingEditor = false
-                    } else {
-                      contentManager.enhanceButtonClicked = false
-                      return
-                    }
-                    
-                    appState.isEnhancingPrompt = true
-                    do {
-                      let enhanced = try await PromptEnhancer.shared.enhance(textToEnhance)
-                      if isEnhancingEditor {
-                        // Update prompt editor text
-                        contentManager.updatePromptEditorText(enhanced)
-                        // Also trigger a refresh in the editor by posting a notification
-                        NotificationCenter.default.post(name: .promptEditorTextUpdated, object: enhanced)
-                      } else {
-                        // Save original for undo support
-                        appState.originalPromptBeforeEnhancement = appState.promptText
-                        appState.promptText = enhanced
-                      }
-                    } catch {
-                      // Handle error - could show alert or tooltip
-                      print("Enhancement error: \(error.localizedDescription)")
-                    }
-                    appState.isEnhancingPrompt = false
-                    // Reset the flag
-                    contentManager.enhanceButtonClicked = false
-                  }
+                } else {
+                  // Enhance prompt with AI
+                  appState.performEnhancePrompt()
                 }
               }) {
                 ZStack {

--- a/nozzle/Views/KeyHandlingView.swift
+++ b/nozzle/Views/KeyHandlingView.swift
@@ -54,24 +54,6 @@ struct KeyHandlingView<Content: View>: View {
               return .handled
             }
             return .handled
-          } else if modifierFlags == [.command, .shift] {
-            // Command-Shift-Enter - paste just the focused item
-            if let item = appState.history.selectedItem {
-              // Clipboard item
-              appState.popup.close()
-              Clipboard.shared.copy(item.item)
-              Clipboard.shared.paste()
-            } else if let focusedItem = contentManager.focusedContentItem {
-              // File source item - skip folders
-              appState.popup.close()
-              if let fileURL = focusedItem.fileURL, !focusedItem.isFolder {
-                let pasteboard = NSPasteboard.general
-                pasteboard.clearContents()
-                pasteboard.writeObjects([fileURL as NSURL])
-                Clipboard.shared.paste()
-              }
-            }
-            return .handled
           } else if modifierFlags == .command {
             // Command-Enter - immediately paste current item (swapped behavior)
             if let item = appState.history.selectedItem {
@@ -141,16 +123,6 @@ struct KeyHandlingView<Content: View>: View {
         case .deleteOneCharFromSearch:
           searchFocused = true
           _ = searchQuery.popLast()
-          return .handled
-        case .deleteLastWordFromSearch:
-          searchFocused = true
-          let newQuery = searchQuery.split(separator: " ").dropLast().joined(separator: " ")
-          if newQuery.isEmpty {
-            searchQuery = ""
-          } else {
-            searchQuery = "\(newQuery) "
-          }
-
           return .handled
         case .moveToNext:
           guard NSApp.characterPickerWindow == nil else {
@@ -302,6 +274,12 @@ struct KeyHandlingView<Content: View>: View {
               Binding(get: { appState.history.searchQuery }, set: { appState.history.searchQuery = $0 }) :
               Binding(get: { appState.promptText }, set: { appState.promptText = $0 })
             await DictationManager.shared.toggleDictation(for: binding)
+          }
+          return .handled
+        case .enhancePrompt:
+          // Enhance prompt if not in search mode
+          if !appState.isSearchMode {
+            appState.performEnhancePrompt()
           }
           return .handled
         case .toggleSelection:

--- a/nozzle/Views/PromptHeaderView.swift
+++ b/nozzle/Views/PromptHeaderView.swift
@@ -58,7 +58,7 @@ struct PromptHeaderView: View {
             .opacity(dictationManager.isRecording ? 1.0 : 0.8)
         }
         .buttonStyle(.plain)
-        .help(dictationManager.isRecording ? "Stop dictation (fn)" : "Start dictation (fn)")
+        .help(dictationManager.isRecording ? "Stop dictation (⌥D)" : "Start dictation (⌥D)")
         
         Spacer()
       }


### PR DESCRIPTION
## Summary
- Improved keyboard shortcuts to avoid conflicts and add new functionality
- Fixed enhance prompt shortcut (⌘E) by centralizing the enhancement logic
- Changed dictation shortcut from ⌃D to ⌥D to prevent conflicts with duplicate commands

## Changes

### 🎹 Keyboard Shortcuts
- **Dictation**: ⌃D → ⌥D (avoids conflicts with duplicate in other apps)
- **Enhance Prompt**: Added ⌘E for AI prompt enhancement
- **Removed redundant**: ⌘⇧Enter (duplicate of ⌘Enter) and ⌃W (non-working delete word)

### 🏗️ Code Improvements
- **Centralized enhancement logic**: Created `AppState.performEnhancePrompt()` method
- **Consistent behavior**: Both button and keyboard shortcut use same enhancement logic
- **Updated help text**: Replaced "fn" references with correct "⌥D" notation
- **Cleaner codebase**: Removed 40+ lines of duplicate code

### ✨ User Experience
- ⌥D follows the app's Option key pattern (⌥V popup, ⌥P pin, ⌥⌫ delete)
- ⌘E provides instant keyboard access to AI prompt enhancement
- No more conflicts with system or app shortcuts

## Test plan
- [x] Test ⌥D dictation shortcut works without conflicts
- [x] Test ⌘E enhance prompt shortcut works in both prompt mode and prompt editor
- [x] Verify help tooltips show correct shortcuts
- [x] Confirm removed shortcuts no longer interfere
- [x] Test enhancement works from both button click and keyboard shortcut

🤖 Generated with [Claude Code](https://claude.ai/code)