### PR TITLE
Add keyboard shortcuts for prompt workflow enhancement

### DIFF
--- a/nozzle/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
+++ b/nozzle/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
@@ -9,4 +9,5 @@ extension KeyboardShortcuts.Name {
   static let togglePromptMode = Self("togglePromptMode", default: Shortcut(.f, modifiers: [.command]))
   static let toggleDictation = Self("toggleDictation", default: Shortcut(.d, modifiers: [.option]))
   static let enhancePrompt = Self("enhancePrompt", default: Shortcut(.e, modifiers: [.command]))
+  static let openPrompts = Self("openPrompts", default: Shortcut(.p, modifiers: [.command]))
 }

--- a/nozzle/KeyChord.swift
+++ b/nozzle/KeyChord.swift
@@ -32,6 +32,9 @@ enum KeyChord: CaseIterable {
   static var enhancePromptKey: Key? { Sauce.shared.key(shortcut: .enhancePrompt) }
   static var enhancePromptModifiers: NSEvent.ModifierFlags? { KeyboardShortcuts.Shortcut(name: .enhancePrompt)?.modifiers }
 
+  static var openPromptsKey: Key? { Sauce.shared.key(shortcut: .openPrompts) }
+  static var openPromptsModifiers: NSEvent.ModifierFlags? { KeyboardShortcuts.Shortcut(name: .openPrompts)?.modifiers }
+
   case clearHistory
   case clearHistoryAll
   case clearSearch
@@ -51,6 +54,7 @@ enum KeyChord: CaseIterable {
   case togglePromptMode
   case toggleDictation
   case enhancePrompt
+  case openPrompts
   case toggleSelection
   case previousTab
   case nextTab
@@ -134,6 +138,8 @@ enum KeyChord: CaseIterable {
       self = .toggleDictation
     case (KeyChord.enhancePromptKey, KeyChord.enhancePromptModifiers):
       self = .enhancePrompt
+    case (KeyChord.openPromptsKey, KeyChord.openPromptsModifiers):
+      self = .openPrompts
     case (.tab, []):
       self = .toggleSelection
     case (.leftBracket, [.command]):

--- a/nozzle/Settings/ShortcutsSettingsPane.swift
+++ b/nozzle/Settings/ShortcutsSettingsPane.swift
@@ -57,6 +57,13 @@ struct ShortcutsSettingsPane: View {
             KeyboardShortcuts.Recorder(for: .toggleDictation)
               .help(Text("Toggle speech-to-text dictation", tableName: "ShortcutsSettings"))
           }
+          
+          HStack {
+            Text("Toggle prompts:", tableName: "ShortcutsSettings")
+              .frame(width: 160, alignment: .trailing)
+            KeyboardShortcuts.Recorder(for: .openPrompts)
+              .help(Text("Toggle prompts tab", tableName: "ShortcutsSettings"))
+          }
         }
       }
 

--- a/nozzle/Views/KeyHandlingView.swift
+++ b/nozzle/Views/KeyHandlingView.swift
@@ -55,6 +55,18 @@ struct KeyHandlingView<Content: View>: View {
             }
             return .handled
           } else if modifierFlags == .command {
+            // Special handling for prompts tab - paste just the prompt content
+            if contentManager.activeSourceId == "prompts",
+               let focusedItem = contentManager.focusedContentItem,
+               let url = focusedItem.fileURL {
+              // Load and paste prompt content directly
+              if let text = TextFileFormatter.loadPlainText(from: url) {
+                appState.popup.close()
+                Clipboard.shared.copyString(text)
+                Clipboard.shared.paste()
+              }
+              return .handled
+            }
             // Command-Enter - immediately paste current item (swapped behavior)
             if let item = appState.history.selectedItem {
               // Clipboard item
@@ -282,8 +294,29 @@ struct KeyHandlingView<Content: View>: View {
             appState.performEnhancePrompt()
           }
           return .handled
+        case .openPrompts:
+          // Toggle prompts tab - open if not active, close if active
+          if contentManager.activeSourceId == "prompts" {
+            // Already in prompts, return to previous tab
+            contentManager.activeSourceId = contentManager.lastNonPromptsSourceId
+          } else {
+            // Not in prompts, open prompts and save current tab
+            contentManager.lastNonPromptsSourceId = contentManager.activeSourceId
+            contentManager.activeSourceId = "prompts"
+          }
+          return .handled
         case .toggleSelection:
-          // Tab key - toggle selection
+          // Special behavior for prompts tab - add as chip and return to previous tab
+          if contentManager.activeSourceId == "prompts",
+             let focusedItem = contentManager.focusedContentItem,
+             let url = focusedItem.fileURL {
+            // Add as prompt chip
+            appState.addPromptChip(url: url)
+            // Return to previous tab
+            contentManager.activeSourceId = contentManager.lastNonPromptsSourceId
+            return .handled
+          }
+          // Default tab behavior for other sources
           if let item = appState.history.selectedItem {
             item.isSelected.toggle()
             appState.updateFooterItemVisibility()


### PR DESCRIPTION
## Summary
Add comprehensive keyboard shortcuts to enhance prompt workflow efficiency:

• **Cmd+P**: Toggle prompts tab (open/close with memory of previous tab)
• **Tab (in prompts)**: Add focused prompt as chip and return to previous tab  
• **Command+Enter (in prompts)**: Paste focused prompt content immediately

## Key Features

### Cmd+P Toggle Behavior
- Opens prompts tab when on any other tab
- Returns to previous tab when already on prompts tab
- Remembers which tab you came from for seamless navigation

### Prompt-Specific Tab Key
- When focused on a prompt: adds it as a chip and automatically returns to previous tab
- Maintains existing toggle selection behavior in other tabs
- Enables keyboard-only workflow for prompt management

### Prompt-Specific Command+Enter
- When focused on a prompt: loads and pastes the prompt content immediately
- Bypasses the chip system for direct prompt usage
- Preserves existing "paste current item" behavior in other tabs

## Implementation Details
- Smart context detection ensures special behavior only applies in prompts tab
- Backward compatible - all existing keyboard shortcuts work unchanged
- Reuses existing functions like `addPromptChip()` and clipboard operations
- Clean separation of prompt-specific vs general keyboard behavior

## Test plan
- [x] Build compiles successfully with no errors
- [ ] Test Cmd+P toggle behavior between tabs
- [ ] Test Tab key in prompts tab (add chip + return)
- [ ] Test Tab key in other tabs (existing behavior)
- [ ] Test Command+Enter in prompts tab (direct paste)
- [ ] Test Command+Enter in other tabs (existing behavior)
- [ ] Verify prompt content loads correctly from various file types

🤖 Generated with [Claude Code](https://claude.ai/code)