### PR TITLE
Fix SwiftData crash in multi-paste operations

### DIFF
--- a/nozzle/Clipboard.swift
+++ b/nozzle/Clipboard.swift
@@ -109,6 +109,45 @@ class Clipboard {
     }
   }
 
+  // Simple data structure to hold clipboard content without SwiftData dependencies
+  struct ClipboardContentData {
+    let type: String
+    let value: Data?
+  }
+  
+  @MainActor
+  func copyContentData(_ contentData: [ClipboardContentData]) {
+    pasteboard.clearContents()
+    
+    for content in contentData {
+      guard content.type != NSPasteboard.PasteboardType.fileURL.rawValue else { continue }
+      pasteboard.setData(content.value, forType: NSPasteboard.PasteboardType(content.type))
+    }
+    
+    // Use writeObjects for file URLs so that multiple files that are copied actually work.
+    // Only do this for file URLs because it causes an issue with some other data types (like formatted text)
+    // where the item is pasted more than once.
+    let fileURLItems: [NSPasteboardItem] = contentData.compactMap { item in
+      guard item.type == NSPasteboard.PasteboardType.fileURL.rawValue else { return nil }
+      guard let value = item.value else { return nil }
+      let pasteItem = NSPasteboardItem()
+      pasteItem.setData(value, forType: NSPasteboard.PasteboardType(item.type))
+      return pasteItem
+    }
+    pasteboard.writeObjects(fileURLItems)
+    
+    // Add nozzle markers
+    pasteboard.setString("", forType: .fromnozzle)
+    sync()
+    
+    if isPerformingMultiPaste {
+      // Update changeCount to prevent the timer from detecting this change
+      changeCount = pasteboard.changeCount
+    } else {
+      checkForChangesInPasteboard()
+    }
+  }
+
   @MainActor
   func copy(_ item: HistoryItem?, removeFormatting: Bool = false) {
     guard let item else { return }
@@ -187,6 +226,73 @@ class Clipboard {
     }
 
     pasteboard.clearContents()
+  }
+
+  // MARK: - Clipboard Backup/Restore for Multi-Paste Operations
+  
+  struct ClipboardSnapshot {
+    let changeCount: Int
+    let items: [PasteboardItemSnapshot]
+    
+    struct PasteboardItemSnapshot {
+      let types: [NSPasteboard.PasteboardType]
+      let data: [NSPasteboard.PasteboardType: Data]
+    }
+  }
+  
+  func captureClipboardState() -> ClipboardSnapshot {
+    var itemSnapshots: [ClipboardSnapshot.PasteboardItemSnapshot] = []
+    
+    pasteboard.pasteboardItems?.forEach { item in
+      var data: [NSPasteboard.PasteboardType: Data] = [:]
+      let types = item.types
+      
+      for type in types {
+        if let itemData = item.data(forType: type) {
+          data[type] = itemData
+        }
+      }
+      
+      itemSnapshots.append(ClipboardSnapshot.PasteboardItemSnapshot(
+        types: types,
+        data: data
+      ))
+    }
+    
+    return ClipboardSnapshot(
+      changeCount: pasteboard.changeCount,
+      items: itemSnapshots
+    )
+  }
+  
+  func restoreClipboardState(_ snapshot: ClipboardSnapshot) {
+    pasteboard.clearContents()
+    
+    // Create new pasteboard items from the snapshot
+    var pasteboardItems: [NSPasteboardItem] = []
+    
+    for itemSnapshot in snapshot.items {
+      let item = NSPasteboardItem()
+      
+      for (type, data) in itemSnapshot.data {
+        item.setData(data, forType: type)
+      }
+      
+      pasteboardItems.append(item)
+    }
+    
+    // Write all items back to the pasteboard
+    if !pasteboardItems.isEmpty {
+      pasteboard.writeObjects(pasteboardItems)
+    }
+    
+    // Sync our internal state
+    sync()
+    
+    // Update change count to prevent detection of this restoration
+    if isPerformingMultiPaste {
+      changeCount = pasteboard.changeCount
+    }
   }
 
   func setMultiPasteMode(_ enabled: Bool) {

--- a/nozzle/Observables/AppState.swift
+++ b/nozzle/Observables/AppState.swift
@@ -357,6 +357,20 @@ class AppState {
     // Store current selection states and prompt text
     let currentPromptText = promptText
     
+    // Capture original clipboard state before any operations
+    let originalClipboardState = Clipboard.shared.captureClipboardState()
+    
+    // Capture clipboard content data early to avoid SwiftData context issues
+    var clipboardContentCache: [UUID: [Clipboard.ClipboardContentData]] = [:]
+    for item in (contextSelectedItems + exampleSelectedItems) where item.sourceType == .clipboard {
+      if let historyDecorator = history.items.first(where: { $0.id == item.id }) {
+        let contentData = historyDecorator.item.contents.map { content in
+          Clipboard.ClipboardContentData(type: content.type, value: content.value)
+        }
+        clipboardContentCache[item.id] = contentData
+      }
+    }
+    
     // Enable multi-paste mode to prevent clipboard monitoring (only for clipboard items)
     let hasClipboardItems = (contextSelectedItems + exampleSelectedItems).contains { $0.sourceType == .clipboard }
     if hasClipboardItems {
@@ -379,7 +393,9 @@ class AppState {
       contextMediaItems: contextMediaItems,
       exampleMediaItems: exampleMediaItems,
       promptText: currentPromptText,
-      hasClipboardItems: hasClipboardItems
+      hasClipboardItems: hasClipboardItems,
+      originalClipboardState: originalClipboardState,
+      clipboardContentCache: clipboardContentCache
     )
   }
   
@@ -390,11 +406,13 @@ class AppState {
     contextMediaItems: [ContentItem],
     exampleMediaItems: [ContentItem],
     promptText: String,
-    hasClipboardItems: Bool
+    hasClipboardItems: Bool,
+    originalClipboardState: Clipboard.ClipboardSnapshot,
+    clipboardContentCache: [UUID: [Clipboard.ClipboardContentData]]
   ) {
     // Step 1: Combine and paste all text content as one operation (off main thread)
     if !contextTextItems.isEmpty || !exampleTextItems.isEmpty || !promptText.isEmpty || !promptChips.isEmpty {
-      Task.detached { [contextTextItems, exampleTextItems, promptText, promptChips] in
+      Task.detached { [contextTextItems, exampleTextItems, promptText, promptChips, originalClipboardState, clipboardContentCache] in
         let plain = await CombinedContentBuilder.build(
           context: contextTextItems,
           examples: exampleTextItems,
@@ -410,7 +428,7 @@ class AppState {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
               // Paste context media first, then example media to preserve order
               let allMedia = contextMediaItems + exampleMediaItems
-              self.pasteMediaItems(allMedia, index: 0, promptText: promptText, hasClipboardItems: hasClipboardItems)
+              self.pasteMediaItems(allMedia, index: 0, promptText: promptText, hasClipboardItems: hasClipboardItems, originalClipboardState: originalClipboardState, clipboardContentCache: clipboardContentCache)
             }
           }
         }
@@ -418,15 +436,15 @@ class AppState {
     } else {
       // No text content, just paste media items
       let allMedia = contextMediaItems + exampleMediaItems
-      pasteMediaItems(allMedia, index: 0, promptText: promptText, hasClipboardItems: hasClipboardItems)
+      pasteMediaItems(allMedia, index: 0, promptText: promptText, hasClipboardItems: hasClipboardItems, originalClipboardState: originalClipboardState, clipboardContentCache: clipboardContentCache)
     }
   }
   
   @MainActor
-  private func pasteMediaItems(_ mediaItems: [ContentItem], index: Int, promptText: String, hasClipboardItems: Bool) {
+  private func pasteMediaItems(_ mediaItems: [ContentItem], index: Int, promptText: String, hasClipboardItems: Bool, originalClipboardState: Clipboard.ClipboardSnapshot, clipboardContentCache: [UUID: [Clipboard.ClipboardContentData]]) {
     guard index < mediaItems.count else {
       // All operations complete, restore state
-      finalizeCombinedPaste(promptText: promptText, hasClipboardItems: hasClipboardItems)
+      finalizeCombinedPaste(promptText: promptText, hasClipboardItems: hasClipboardItems, originalClipboardState: originalClipboardState)
       return
     }
     
@@ -435,7 +453,7 @@ class AppState {
     // Skip folders - their contents are already captured in the selection
     if item.isFolder {
       // Move to next item without pasting
-      pasteMediaItems(mediaItems, index: index + 1, promptText: promptText, hasClipboardItems: hasClipboardItems)
+      pasteMediaItems(mediaItems, index: index + 1, promptText: promptText, hasClipboardItems: hasClipboardItems, originalClipboardState: originalClipboardState, clipboardContentCache: clipboardContentCache)
       return
     }
     
@@ -450,10 +468,10 @@ class AppState {
       pasteboard.clearContents()
       pasteboard.writeObjects([fileURL as NSURL])
     } else if item.sourceType == .clipboard {
-      // For clipboard items without fileURL, use the original HistoryItem copy method  
-      // to preserve all clipboard data types (like multiple file URLs)
-      if let historyDecorator = history.items.first(where: { $0.id == item.id }) {
-        Clipboard.shared.copy(historyDecorator.item)
+      // For clipboard items without fileURL, use cached content data
+      // to avoid SwiftData context issues
+      if let contentData = clipboardContentCache[item.id] {
+        Clipboard.shared.copyContentData(contentData)
       }
     }
     
@@ -463,17 +481,20 @@ class AppState {
       
       // Wait before next media item
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-        self.pasteMediaItems(mediaItems, index: index + 1, promptText: promptText, hasClipboardItems: hasClipboardItems)
+        self.pasteMediaItems(mediaItems, index: index + 1, promptText: promptText, hasClipboardItems: hasClipboardItems, originalClipboardState: originalClipboardState, clipboardContentCache: clipboardContentCache)
       }
     }
   }
   
   @MainActor
-  private func finalizeCombinedPaste(promptText: String, hasClipboardItems: Bool) {
+  private func finalizeCombinedPaste(promptText: String, hasClipboardItems: Bool, originalClipboardState: Clipboard.ClipboardSnapshot) {
     // Disable multi-paste mode (only if we had clipboard items)
     if hasClipboardItems {
       Clipboard.shared.setMultiPasteMode(false)
     }
+    
+    // Restore original clipboard content to prevent combined text from lingering
+    Clipboard.shared.restoreClipboardState(originalClipboardState)
     
     // Only call this in the App Store version.
     AppStoreReview.ask()

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -22,6 +22,8 @@ final class ContentManager {
     private(set) var selectedItemIds: Set<UUID> = []
     // Subset of selected items that are marked as examples
     private(set) var exampleItemIds: Set<UUID> = []
+    // Observable version counter to trigger UI updates when selection changes
+    private(set) var selectionVersion: Int = 0
     
     // Preview focus tracking
     private(set) var focusedItemId: UUID?
@@ -47,6 +49,7 @@ final class ContentManager {
     // (Removed) Aggregated display version tracking; Aggregated now shows only pasteable items
     
     var selectedItems: [ContentItem] {
+        _ = selectionVersion  // Establish dependency for SwiftUI observation
         if _selectedCacheDirty {
             _selectedCache = makeSelectedItems()
             _selectedCacheDirty = false
@@ -306,6 +309,16 @@ final class ContentManager {
         sources[source.id] = source
         if !orderedSourceIds.contains(source.id) {
             orderedSourceIds.append(source.id)
+        }
+        
+        // Sync initial selection state for clipboard items
+        if source is ClipboardSource {
+            for item in History.shared.items where item.isSelected {
+                selectedItemIds.insert(item.id)
+            }
+            if !selectedItemIds.isEmpty {
+                markSelectedDirty()
+            }
         }
     }
     
@@ -636,6 +649,7 @@ extension Notification.Name {
 extension ContentManager {
     func markSelectedDirty() {
         _selectedCacheDirty = true
+        selectionVersion += 1  // Force UI update
     }
     
     private func makeSelectedItems() -> [ContentItem] {

--- a/nozzle/Views/KeyHandlingView.swift
+++ b/nozzle/Views/KeyHandlingView.swift
@@ -318,7 +318,7 @@ struct KeyHandlingView<Content: View>: View {
           }
           // Default tab behavior for other sources
           if let item = appState.history.selectedItem {
-            item.isSelected.toggle()
+            contentManager.toggleSelection(item.id)
             appState.updateFooterItemVisibility()
           }
           return .handled
@@ -355,7 +355,7 @@ struct KeyHandlingView<Content: View>: View {
            let key = Sauce.shared.key(for: Int(event.keyCode)),
            let item = appState.history.items.first(where: { $0.shortcuts.contains(where: { $0.key == key }) }) {
           // Toggle the item's selection
-          item.isSelected.toggle()
+          contentManager.toggleSelection(item.id)
           appState.selection = item.id
           appState.updateFooterItemVisibility()
           return .handled


### PR DESCRIPTION
## Summary
- Fix critical SwiftData crash during multi-paste operations
- Resolve selection synchronization issues between UI and ContentManager
- Enhance clipboard restoration to prevent unwanted history entries
- Add real-time badge updates for selected items tab

## Root Cause Analysis
The crash occurred when `HistoryItemContent.type.getter` was accessed after SwiftData context invalidation:

1. Multi-paste operations called `Clipboard.shared.copy(historyDecorator.item)` 
2. This accessed `item.contents` (SwiftData objects) to read `type` and `value` properties
3. Clipboard restoration logic called `restoreClipboardState()` → `sync()` 
4. Async operations from `DispatchQueue.main.asyncAfter` then crashed accessing invalid SwiftData objects

**Stack trace showed**: `Fatal error: Never access a full future backing data - PersistentIdentifier(...) with nil`

## Technical Solution

### 1. SwiftData Context Safety
- **Added `ClipboardContentData` struct**: Simple data container without SwiftData dependencies
- **Added `copyContentData()` method**: Copies clipboard content using raw data instead of SwiftData objects
- **Early data capture**: Extract `type`/`value` from `HistoryItemContent` objects before any context invalidation
- **Updated method signatures**: Pass cached data through entire multi-paste flow

### 2. Selection Synchronization
- **Fixed `KeyHandlingView.swift`**: Replace direct `item.isSelected.toggle()` with `contentManager.toggleSelection()`
- **Enhanced `ContentManager.registerSource()`**: Sync pre-existing selected items from History into selectedItemIds
- **Centralized selection state**: Ensure UI reflects ContentManager's authoritative selection state

### 3. Real-time Badge Updates  
- **Added `selectionVersion` counter**: Observable property that increments on selection changes
- **Enhanced `selectedItems` computed property**: Explicit dependency on `selectionVersion` for SwiftUI observation
- **Fixed badge responsiveness**: Selected tab badge now updates immediately when items are selected

## Test Plan
- [x] Build succeeds without compilation errors
- [ ] Multi-paste operations complete without crashes
- [ ] Selection state stays synchronized between UI and ContentManager  
- [ ] Selected items tab badge updates in real-time
- [ ] Combined text doesn't inappropriately enter clipboard history
- [ ] Clipboard restoration works correctly for text-only and mixed-media operations

## Files Changed
- `nozzle/Clipboard.swift`: Added SwiftData-safe clipboard content handling
- `nozzle/Observables/AppState.swift`: Enhanced multi-paste flow with early data capture
- `nozzle/Observables/ContentManager.swift`: Fixed selection sync and badge updates
- `nozzle/Views/KeyHandlingView.swift`: Centralized selection through ContentManager

🤖 Generated with [Claude Code](https://claude.ai/code)