### PR TITLE
Add right-click shortcut preview enhancements and keyboard shortcuts

### DIFF
--- a/nozzle/AppDelegate.swift
+++ b/nozzle/AppDelegate.swift
@@ -285,6 +285,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     AppState.shared.quit()
   }
   
+  @MainActor
+  private func dismissMenuBarTooltipIfPresent() {
+    menuBarTooltip?.dismiss()
+  }
+
 
   private func synchronizeMenuIconText() {
     _ = withObservationTracking {
@@ -338,7 +343,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       object: panel,
       queue: .main
     ) { [weak self] _ in
-      self?.menuBarTooltip?.dismiss()
+      Task { @MainActor in
+        self?.dismissMenuBarTooltipIfPresent()
+      }
     }
   }
 }

--- a/nozzle/Clipboard.swift
+++ b/nozzle/Clipboard.swift
@@ -401,9 +401,6 @@ class Clipboard {
         }
       }
     }
-    // Swallow any errors silently; fallback behavior will still capture the URL
-    catch {
-    }
 
     guard !contents.isEmpty else {
       return

--- a/nozzle/Extensions/Sauce+KeyboardShortcuts.swift
+++ b/nozzle/Extensions/Sauce+KeyboardShortcuts.swift
@@ -1,5 +1,7 @@
 import KeyboardShortcuts
 import Sauce
+import SwiftUI
+import AppKit
 
 extension Sauce {
   func key(shortcut: KeyboardShortcuts.Name) -> Key? {
@@ -8,5 +10,17 @@ extension Sauce {
     } else {
       return nil
     }
+  }
+}
+
+// Map a KeyboardShortcuts.Shortcut to SwiftUI EventModifiers for use in .keyboardShortcut
+extension KeyboardShortcuts.Shortcut {
+  func toEventModifiers() -> EventModifiers {
+    var mods: EventModifiers = []
+    if modifiers.contains(.command) { mods.insert(.command) }
+    if modifiers.contains(.option) { mods.insert(.option) }
+    if modifiers.contains(.control) { mods.insert(.control) }
+    if modifiers.contains(.shift) { mods.insert(.shift) }
+    return mods
   }
 }

--- a/nozzle/Onboarding/MenuBarTooltip.swift
+++ b/nozzle/Onboarding/MenuBarTooltip.swift
@@ -65,12 +65,16 @@ class MenuBarTooltip: NSWindow {
         // Set up auto-dismiss timer (5 seconds)
         dismissTimer?.invalidate()
         dismissTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { [weak self] _ in
-            self?.dismiss()
+            Task { @MainActor in
+                self?.dismiss()
+            }
         }
         
         // Dismiss on any click
         NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] event in
-            self?.dismiss()
+            Task { @MainActor in
+                self?.dismiss()
+            }
             return event
         }
     }
@@ -84,7 +88,9 @@ class MenuBarTooltip: NSWindow {
             context.timingFunction = CAMediaTimingFunction(name: .easeIn)
             self.animator().alphaValue = 0.0
         }, completionHandler: {
-            self.orderOut(nil)
+            Task { @MainActor in
+                self.orderOut(nil)
+            }
         })
     }
 }

--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftData
 import SwiftUI
+import KeyboardShortcuts
 
 struct ContentView: View {
   @State private var appState = AppState.shared
@@ -259,6 +260,10 @@ struct ContentView: View {
                       contentManager.activeSourceId = "prompts"
                     }
                   }
+                  .keyboardShortcut(
+                    KeyEquivalent("p"),
+                    modifiers: KeyboardShortcuts.Shortcut(name: .openPrompts)?.toEventModifiers() ?? [.command]
+                  )
                 }
               }
               
@@ -489,25 +494,31 @@ struct ContentView: View {
                     Button("Copy All") {
                       appState.performCombinedPaste()
                     }
+                    .keyboardShortcut(KeyEquivalent("v"), modifiers: [.command])
                     
                     Button("Clear Selection") {
                       contentManager.clearSelection()
                       appState.updateFooterItemVisibility()
                     }
+                    .keyboardShortcut(
+                      .backspace,
+                      modifiers: KeyboardShortcuts.Shortcut(name: .clearSelection)?.toEventModifiers() ?? [.command]
+                    )
                     
                     Divider()
                     
-                    if !contextItems.isEmpty {
-                      Button("Convert All to Examples") {
-                        for item in contextItems {
+                    // Put Context above Example
+                    if !exampleItems.isEmpty {
+                      Button("Convert All to Context") {
+                        for item in exampleItems {
                           contentManager.toggleExample(item.id)
                         }
                       }
                     }
                     
-                    if !exampleItems.isEmpty {
-                      Button("Convert All to Context") {
-                        for item in exampleItems {
+                    if !contextItems.isEmpty {
+                      Button("Convert All to Examples") {
+                        for item in contextItems {
                           contentManager.toggleExample(item.id)
                         }
                       }

--- a/nozzle/Views/HistoryItemView.swift
+++ b/nozzle/Views/HistoryItemView.swift
@@ -1,5 +1,6 @@
 import Defaults
 import SwiftUI
+import KeyboardShortcuts
 
 struct HistoryItemView: View {
   @Bindable var item: HistoryItemDecorator
@@ -100,22 +101,32 @@ struct HistoryItemView: View {
       Button(item.isPinned ? "Unpin" : "Pin") {
         appState.history.togglePin(item)
       }
+      .keyboardShortcut(
+        KeyEquivalent("p"),
+        modifiers: KeyboardShortcuts.Shortcut(name: .pin)?.toEventModifiers() ?? [.option]
+      )
       
       Button("Delete") {
         appState.highlightNext()
         appState.history.delete(item)
       }
+      .keyboardShortcut(
+        .backspace,
+        modifiers: KeyboardShortcuts.Shortcut(name: .delete)?.toEventModifiers() ?? [.option]
+      )
       
       Divider()
       
-      Button(contentManager.isExample(item.id) ? "Remove as Example" : "Mark as Example") {
-        contentManager.toggleExample(item.id)
-      }
-      
+      // Put Context above Example
       Button(contentManager.isSelected(item.id) ? "Remove as Context" : "Mark as Context") {
         contentManager.toggleSelection(item.id)
         item.isSelected = contentManager.isSelected(item.id)
         appState.updateFooterItemVisibility()
+      }
+      .keyboardShortcut(.tab)
+
+      Button(contentManager.isExample(item.id) ? "Remove as Example" : "Mark as Example") {
+        contentManager.toggleExample(item.id)
       }
     }
   }

--- a/nozzle/Views/UniversalItemView.swift
+++ b/nozzle/Views/UniversalItemView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Defaults
 import AppKit
+import KeyboardShortcuts
 
 @MainActor
 private extension UniversalItemView {
@@ -220,6 +221,10 @@ struct UniversalItemView: View {
                 Button("Delete", role: .destructive) {
                     (contentManager.sources["prompts"] as? PromptsSource)?.deletePrompt(at: url)
                 }
+                .keyboardShortcut(
+                    .backspace,
+                    modifiers: KeyboardShortcuts.Shortcut(name: .delete)?.toEventModifiers() ?? [.option]
+                )
             } else if !item.base.isFolder, let url = item.base.fileURL {
                 // Context menu for regular files
                 Button("Copy") {
@@ -238,13 +243,15 @@ struct UniversalItemView: View {
                 
                 Divider()
                 
-                Button(contentManager.isExample(item.id) ? "Remove as Example" : "Mark as Example") {
-                    contentManager.toggleExample(item.id)
-                }
-                
+                // Put Context above Example
                 Button(contentManager.isSelected(item.id) ? "Remove as Context" : "Mark as Context") {
                     contentManager.toggleSelection(item.id)
                     appState.updateFooterItemVisibility()
+                }
+                .keyboardShortcut(.tab)
+                
+                Button(contentManager.isExample(item.id) ? "Remove as Example" : "Mark as Example") {
+                    contentManager.toggleExample(item.id)
                 }
                 
                 Divider()


### PR DESCRIPTION
## Summary
- Enhanced right-click context menus with keyboard shortcut previews
- Added keyboard shortcuts to common actions (Copy All, Clear Selection, Pin/Unpin, Delete)
- Improved menu organization by reordering Context above Example for better UX
- Added MainActor annotations for thread-safe UI operations  
- Extended KeyboardShortcuts with SwiftUI EventModifiers conversion utility

## Test plan
- [ ] Test right-click context menus show keyboard shortcuts
- [ ] Verify all keyboard shortcuts work as expected
- [ ] Test menu organization (Context appears above Example)
- [ ] Verify MainActor thread safety improvements
- [ ] Test across different content sources (clipboard, files, prompts)

🤖 Generated with [Claude Code](https://claude.ai/code)