### PR TITLE
Refine onboarding UI with improved spacing and streamlined tooltips

### DIFF
--- a/nozzle/Onboarding/MenuBarTooltip.swift
+++ b/nozzle/Onboarding/MenuBarTooltip.swift
@@ -11,7 +11,7 @@ class MenuBarTooltip: NSWindow {
         self.tooltipView = TooltipContentView()
         
         // Calculate initial size
-        let initialSize = CGSize(width: 280, height: 80)
+        let initialSize = CGSize(width: 180, height: 60)
         
         // Initialize window
         super.init(
@@ -48,7 +48,7 @@ class MenuBarTooltip: NSWindow {
         
         // Position below the menu bar button with some offset
         let xPosition = buttonFrame.midX - (tooltipWidth / 2)
-        let yPosition = buttonFrame.minY - tooltipHeight - 12 // 12px gap from menu bar
+        let yPosition = buttonFrame.minY - tooltipHeight - 1 // 1px gap from menu bar (very close)
         
         self.setFrameOrigin(NSPoint(x: xPosition, y: yPosition))
         
@@ -108,29 +108,9 @@ struct TooltipContentView: View {
                 .offset(y: 1) // Slight overlap to connect with body
             
             // Main content
-            HStack(spacing: 12) {
-                Image(systemName: "v.circle.fill")
-                    .font(.system(size: 24))
-                    .foregroundColor(accentColor)
-                
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Nozzle is ready!")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(.primary)
-                    
-                    HStack(spacing: 4) {
-                        Label("⌥V", systemImage: "option")
-                            .font(.system(size: 13, weight: .medium, design: .monospaced))
-                            .foregroundColor(.secondary)
-                        
-                        Text("or click here to open")
-                            .font(.system(size: 13))
-                            .foregroundColor(.secondary)
-                    }
-                }
-                
-                Spacer()
-            }
+            Text("Click here or by ⌥ + V")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.primary)
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
             .background(

--- a/nozzle/Onboarding/OnboardingState.swift
+++ b/nozzle/Onboarding/OnboardingState.swift
@@ -40,7 +40,7 @@ final class OnboardingState {
     
     var currentScreen: Screen = .welcomeSetup
     var hasAccessibilityPermission = false
-    var launchAtLoginEnabled = false
+    var launchAtLoginEnabled = true  // Default to ON
     
     // Computed properties
     var canContinue: Bool {

--- a/nozzle/Onboarding/Screens/DemoScreen.swift
+++ b/nozzle/Onboarding/Screens/DemoScreen.swift
@@ -7,6 +7,13 @@ struct DemoScreen: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 14) {
+                // Demo Video header
+                Text("Demo Video")
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundColor(.primary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.bottom, 16)
+                
                 // Video wireframe only (keep placeholder, remove extra copy)
                 videoWireframe
             }

--- a/nozzle/Onboarding/Screens/GetStartedScreen.swift
+++ b/nozzle/Onboarding/Screens/GetStartedScreen.swift
@@ -12,6 +12,10 @@ struct GetStartedScreen: View {
                 // Success header
                 successSection
 
+                // Screenshot wireframe
+                screenshotWireframe
+                    .padding(.vertical, 8)
+
                 // Resources section
                 resourcesTiles
             }
@@ -44,6 +48,32 @@ struct GetStartedScreen: View {
         }
     }
 
+    /// Wireframe placeholder for screenshot
+    @ViewBuilder
+    private var screenshotWireframe: some View {
+        RoundedRectangle(cornerRadius: 15)
+            .stroke(Color.secondary.opacity(0.3), style: StrokeStyle(lineWidth: 2, dash: [8, 4]))
+            .fill(Color(NSColor.controlBackgroundColor).opacity(0.3))
+            .frame(height: 200)
+            .overlay {
+                VStack(spacing: 12) {
+                    Image(systemName: "photo")
+                        .font(.system(size: 32))
+                        .foregroundStyle(.secondary)
+                    
+                    Text("App Screenshot")
+                        .font(.system(.body, weight: .medium))
+                        .foregroundStyle(.secondary)
+                    
+                    Text("Screenshot placeholder - will be replaced with actual app image")
+                        .font(.system(.caption))
+                        .foregroundStyle(.tertiary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 20)
+                }
+            }
+    }
+
     // Resources as tiles styled like Shortcuts
     @ViewBuilder
     private var resourcesTiles: some View {
@@ -68,12 +98,6 @@ struct GetStartedScreen: View {
                     title: "Anthropic Prompt Library",
                     subtitle: "Proven prompts",
                     url: "https://docs.anthropic.com/claude/prompt-library"
-                )
-                resourceTile(
-                    icon: "book.closed",
-                    title: "Nozzle Docs",
-                    subtitle: "Guides & tips",
-                    url: "https://github.com/openai" // Placeholder; replace with real docs URL
                 )
             }
         }

--- a/nozzle/Onboarding/Screens/ShortcutsScreen.swift
+++ b/nozzle/Onboarding/Screens/ShortcutsScreen.swift
@@ -62,7 +62,7 @@ struct ShortcutsScreen: View {
         RoundedRectangle(cornerRadius: 15)
             .stroke(Color.secondary.opacity(0.3), style: StrokeStyle(lineWidth: 2, dash: [8, 4]))
             .fill(Color(NSColor.controlBackgroundColor).opacity(0.3))
-            .frame(height: 200)
+            .frame(height: 300)  // Set to 300px height
             .overlay {
                 VStack(spacing: 12) {
                     Image(systemName: "photo")

--- a/nozzle/Onboarding/Screens/WelcomeSetupScreen.swift
+++ b/nozzle/Onboarding/Screens/WelcomeSetupScreen.swift
@@ -11,6 +11,7 @@ struct WelcomeSetupScreen: View {
             VStack(spacing: 14) {
                 // App header
                 welcomeHeader
+                    .padding(.bottom, 12)  // Add extra padding after welcome
                 // Permissions section
                 permissionsSection
                 


### PR DESCRIPTION
## Summary
- Enhanced onboarding flow with improved visual hierarchy and spacing
- Streamlined menu bar tooltip for better user experience
- Refined resource presentation and screenshot placeholders

## Changes Made

### Welcome Screen
- Added padding between Welcome header and Accessibility section for better visual separation
- Set Launch at Login to ON by default for improved user experience

### Shortcuts Screen  
- Increased app screenshot wireframe height to 300px for better proportions

### Demo Screen
- Centered "Demo Video" header with enhanced spacing (16px bottom padding)

### Get Started Screen
- Removed "Nozzle Docs" resource tile, keeping only OpenAI and Anthropic resources
- Added screenshot wireframe placeholder (200px height) above resources section

### Menu Bar Tooltip
- Simplified tooltip text to just "Click here or by ⌥ + V"
- Reduced tooltip size from 280x80 to 180x60 pixels
- Positioned tooltip 1px from menu bar for better visual connection

## Test Plan
- [ ] Verify onboarding flow displays correctly with new spacing
- [ ] Confirm Launch at Login defaults to ON 
- [ ] Check screenshot wireframes render at correct sizes
- [ ] Test menu bar tooltip appears with simplified text and close positioning
- [ ] Ensure all text and spacing improvements maintain visual consistency

🤖 Generated with [Claude Code](https://claude.ai/code)