### PR TITLE
Add feedback button to menu bar context menu

### DIFF
--- a/nozzle/AppDelegate.swift
+++ b/nozzle/AppDelegate.swift
@@ -33,6 +33,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     // Bridge FloatingPanel via AppDelegate.
     AppState.shared.appDelegate = self
+    
+    // Register global feedback shortcut
+    KeyboardShortcuts.onKeyUp(for: .sendFeedback) { [weak self] in
+      Task { @MainActor in
+        self?.sendFeedbackFromMenu()
+      }
+    }
 
     Clipboard.shared.onNewCopy { History.shared.add($0) }
     Clipboard.shared.start()
@@ -254,6 +261,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     shortcutsItem.target = self
     menu.addItem(shortcutsItem)
     
+    let feedbackItem = NSMenuItem(
+      title: NSLocalizedString("Feedback", comment: ""),
+      action: #selector(sendFeedbackFromMenu),
+      keyEquivalent: "f"
+    )
+    feedbackItem.keyEquivalentModifierMask = [.option]
+    feedbackItem.target = self
+    menu.addItem(feedbackItem)
+    
     menu.addItem(NSMenuItem.separator())
     
     let quitItem = NSMenuItem(
@@ -280,6 +296,32 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     AppState.shared.showingShortcuts = true
   }
 
+  @objc
+  private func sendFeedbackFromMenu() {
+    let email = "conor.omeara@icloud.com"
+    let subject = "Nozzle Feedback"
+    let body = """
+    Hi Conor,
+
+    I'd like to share some feedback about Nozzle:
+
+    
+
+    ---
+    App Version: \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown")
+    Build: \(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown")
+    macOS: \(ProcessInfo.processInfo.operatingSystemVersionString)
+    """
+    
+    let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? subject
+    let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? body
+    let mailtoString = "mailto:\(email)?subject=\(encodedSubject)&body=\(encodedBody)"
+    
+    if let mailtoURL = URL(string: mailtoString) {
+      NSWorkspace.shared.open(mailtoURL)
+    }
+  }
+  
   @objc
   private func quitFromMenu() {
     AppState.shared.quit()

--- a/nozzle/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
+++ b/nozzle/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
@@ -11,4 +11,5 @@ extension KeyboardShortcuts.Name {
   static let enhancePrompt = Self("enhancePrompt", default: Shortcut(.e, modifiers: [.command]))
   static let showShortcuts = Self("showShortcuts", default: Shortcut(.slash, modifiers: [.command]))
   static let openPrompts = Self("openPrompts", default: Shortcut(.p, modifiers: [.command]))
+  static let sendFeedback = Self("sendFeedback", default: Shortcut(.f, modifiers: [.option]))
 }

--- a/nozzle/Models/ShortcutCategory.swift
+++ b/nozzle/Models/ShortcutCategory.swift
@@ -100,6 +100,7 @@ struct ShortcutItem: Identifiable, Hashable {
         case .enhancePrompt: return [.modifier("⌘"), .key("E")]
         case .showShortcuts: return [.modifier("⌘"), .key("/")]
         case .openPrompts: return [.modifier("⌘"), .key("P")]
+        case .sendFeedback: return [.modifier("⌥"), .key("F")]
         default: return [.key("?")]
         }
     }
@@ -184,6 +185,7 @@ enum ShortcutData {
             ShortcutItem("Close popup", fixed: .special("Esc")),
             ShortcutItem("Open preferences", fixed: .modifier("⌘"), .key(",")),
             ShortcutItem("Show keyboard shortcuts", customizable: .showShortcuts),
+            ShortcutItem("Send feedback", customizable: .sendFeedback),
             ShortcutItem("Open prompts", customizable: .openPrompts)
         ]),
         

--- a/nozzle/en.lproj/Localizable.strings
+++ b/nozzle/en.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "copy_combined" = "Copy to Clipboard";
 "quit" = "Quit";
 "preferences" = "Preferences…";
+"Feedback" = "Feedback";
 "preferences_advanced" = "Advanced";
 "preferences_pins" = "Pins";
 "copy_modifiers_config" = "• Select with %@ pressed to copy item.";


### PR DESCRIPTION
## Summary
- Added a feedback button to the menu bar item's right-click context menu
- Implemented global keyboard shortcut (Option+F) for quick feedback access
- Opens user's default email client with pre-filled feedback template

## Features
- **Context Menu**: New "Feedback" item appears in the right-click menu between "Keyboard Shortcuts" and the separator
- **Global Shortcut**: Option+F works anywhere in macOS to trigger feedback
- **Email Template**: Pre-fills email with:
  - To: conor.omeara@icloud.com
  - Subject: "Nozzle Feedback"
  - Body with system info (app version, build, macOS version)
- **Customizable**: Shortcut can be changed in preferences
- **Localized**: Added localization support for the "Feedback" menu item

## Test Plan
- [x] Right-click menu bar item and verify "Feedback" appears
- [x] Click "Feedback" menu item to verify email client opens with template
- [x] Press Option+F globally to verify shortcut works
- [x] Check keyboard shortcuts panel shows "Send feedback" with Option+F
- [x] Build succeeds without errors

🤖 Generated with [Claude Code](https://claude.ai/code)