### PR TITLE
Refine onboarding resources page layout and prioritization

### DIFF
--- a/nozzle/Onboarding/Screens/GetStartedScreen.swift
+++ b/nozzle/Onboarding/Screens/GetStartedScreen.swift
@@ -12,12 +12,9 @@ struct GetStartedScreen: View {
                 // Success header
                 successSection
 
-                // Screenshot wireframe
-                screenshotWireframe
-                    .padding(.vertical, 8)
-
                 // Resources section
                 resourcesTiles
+                    .padding(.top, 30)
             }
             .padding(.horizontal, 26)
             .padding(.vertical, 14)
@@ -48,31 +45,6 @@ struct GetStartedScreen: View {
         }
     }
 
-    /// Wireframe placeholder for screenshot
-    @ViewBuilder
-    private var screenshotWireframe: some View {
-        RoundedRectangle(cornerRadius: 15)
-            .stroke(Color.secondary.opacity(0.3), style: StrokeStyle(lineWidth: 2, dash: [8, 4]))
-            .fill(Color(NSColor.controlBackgroundColor).opacity(0.3))
-            .frame(height: 200)
-            .overlay {
-                VStack(spacing: 12) {
-                    Image(systemName: "photo")
-                        .font(.system(size: 32))
-                        .foregroundStyle(.secondary)
-                    
-                    Text("App Screenshot")
-                        .font(.system(.body, weight: .medium))
-                        .foregroundStyle(.secondary)
-                    
-                    Text("Screenshot placeholder - will be replaced with actual app image")
-                        .font(.system(.caption))
-                        .foregroundStyle(.tertiary)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 20)
-                }
-            }
-    }
 
     // Resources as tiles styled like Shortcuts
     @ViewBuilder
@@ -88,16 +60,16 @@ struct GetStartedScreen: View {
             let columns = [GridItem(.adaptive(minimum: 200), spacing: 16, alignment: .top)]
             LazyVGrid(columns: columns, spacing: 16) {
                 resourceTile(
-                    icon: "brain.head.profile",
-                    title: "OpenAI Prompt Engineering",
-                    subtitle: "Effective prompting",
-                    url: "https://platform.openai.com/docs/guides/prompt-engineering"
-                )
-                resourceTile(
                     icon: "sparkles",
                     title: "Anthropic Prompt Library",
                     subtitle: "Proven prompts",
                     url: "https://docs.anthropic.com/claude/prompt-library"
+                )
+                resourceTile(
+                    icon: "brain.head.profile",
+                    title: "OpenAI Prompt Engineering",
+                    subtitle: "Effective prompting",
+                    url: "https://platform.openai.com/docs/guides/prompt-engineering"
                 )
             }
         }


### PR DESCRIPTION
## Summary
- Remove screenshot wireframe placeholder from final onboarding screen for cleaner appearance
- Reorganize resources to prioritize Anthropic before OpenAI in the resources grid
- Add increased spacing (30pt) before resources section for better visual hierarchy

## Test plan
- [ ] Build and run the app
- [ ] Complete the onboarding flow to the final "Get Started" screen
- [ ] Verify the screenshot wireframe is no longer displayed
- [ ] Confirm Anthropic Prompt Library appears before OpenAI Prompt Engineering
- [ ] Check that the resources section has appropriate spacing from the success header

🤖 Generated with [Claude Code](https://claude.ai/code)