### PR TITLE
Improve content selection performance and folder accuracy

### DIFF
--- a/nozzle/Observables/ClipboardSource.swift
+++ b/nozzle/Observables/ClipboardSource.swift
@@ -129,6 +129,7 @@ private extension ClipboardSource {
         utiCache[id] = identifier
         metadataVersion &+= 1
         ContentManager.shared.markItemsDirty()
+        ContentManager.shared.markSelectedDirty()
         ContentManager.shared.markDecoratorsNeedRefresh(for: self.id)
     }
 }

--- a/nozzle/Observables/ClipboardSource.swift
+++ b/nozzle/Observables/ClipboardSource.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Observation
+import UniformTypeIdentifiers
 
 @Observable @MainActor
 final class ClipboardSource: ContentSource {
@@ -11,6 +12,10 @@ final class ClipboardSource: ContentSource {
     private let history: History = History.shared      // existing model
     @ObservationIgnored private var cachedItems: [ContentItem] = []
     @ObservationIgnored private var cachedVersion: Int = -1
+    @ObservationIgnored private var cachedMetadataVersion: Int = -1
+    @ObservationIgnored private var metadataVersion: Int = 0
+    @ObservationIgnored private var utiCache: [UUID: String?] = [:]
+    @ObservationIgnored private var pendingUTIRequests: [UUID: Task<String?, Never>] = [:]
     var isMonitoring: Bool { true }                    // handled by Clipboard itself
     var searchQuery: String {
         get { history.searchQuery }
@@ -19,18 +24,10 @@ final class ClipboardSource: ContentSource {
     
     var items: [ContentItem] {
         let version = history.itemsRevision
-        if version != cachedVersion {
+        if version != cachedVersion || cachedMetadataVersion != metadataVersion {
+            let decorators = history.items
             cachedItems = history.items.map { decorator in
-                // Get UTI for file URLs to enable proper file type badges
-                let uniformTypeIdentifier: String? = {
-                    if let fileURL = decorator.item.fileURLs.first,
-                       let resourceValues = try? fileURL.resourceValues(forKeys: [.contentTypeKey]),
-                       let contentType = resourceValues.contentType {
-                        return contentType.identifier
-                    }
-                    return nil
-                }()
-                
+                let uniformTypeIdentifier = uniformTypeIdentifier(for: decorator)
                 return ContentItem(
                     id: decorator.id,
                     title: decorator.title,
@@ -48,7 +45,10 @@ final class ClipboardSource: ContentSource {
                     isVisible: decorator.isVisible
                 )
             }
+            let activeIds = Set(decorators.map { $0.id })
+            cleanupUTICache(keeping: activeIds)
             cachedVersion = version
+            cachedMetadataVersion = metadataVersion
         }
         return cachedItems
     }
@@ -67,5 +67,68 @@ final class ClipboardSource: ContentSource {
     
     func search(query: String) -> [ContentItem] {
         items.filter { $0.title.localizedCaseInsensitiveContains(query) }
+    }
+}
+
+private extension ClipboardSource {
+    func uniformTypeIdentifier(for decorator: HistoryItemDecorator) -> String? {
+        if let cached = utiCache[decorator.id] { return cached }
+
+        guard let fileURL = decorator.item.fileURLs.first else {
+            utiCache[decorator.id] = nil
+            return nil
+        }
+
+        scheduleUTIResolution(for: decorator.id, fileURL: fileURL)
+        return nil
+    }
+
+    func scheduleUTIResolution(for id: UUID, fileURL: URL) {
+        guard pendingUTIRequests[id] == nil else { return }
+
+        pendingUTIRequests[id] = Task.detached(priority: .utility) { [weak self] () -> String? in
+            let identifier: String?
+            if let values = try? fileURL.resourceValues(forKeys: [.contentTypeKey]) {
+                identifier = values.contentType?.identifier
+            } else {
+                identifier = nil
+            }
+
+            if Task.isCancelled {
+                await self?.clearPendingUTIRequest(for: id)
+                return nil
+            }
+
+            await self?.applyResolvedUTI(identifier, for: id)
+
+            return identifier
+        }
+    }
+
+    func cleanupUTICache(keeping ids: Set<UUID>) {
+        let staleCacheIds = utiCache.keys.filter { !ids.contains($0) }
+        for key in staleCacheIds {
+            utiCache.removeValue(forKey: key)
+        }
+
+        let staleTasks = pendingUTIRequests.keys.filter { !ids.contains($0) }
+        for key in staleTasks {
+            pendingUTIRequests[key]?.cancel()
+            pendingUTIRequests.removeValue(forKey: key)
+        }
+    }
+
+    @MainActor
+    func clearPendingUTIRequest(for id: UUID) {
+        pendingUTIRequests[id] = nil
+    }
+
+    @MainActor
+    func applyResolvedUTI(_ identifier: String?, for id: UUID) {
+        pendingUTIRequests[id] = nil
+        utiCache[id] = identifier
+        metadataVersion &+= 1
+        ContentManager.shared.markItemsDirty()
+        ContentManager.shared.markDecoratorsNeedRefresh(for: self.id)
     }
 }

--- a/nozzle/Observables/ClipboardSource.swift
+++ b/nozzle/Observables/ClipboardSource.swift
@@ -9,6 +9,8 @@ final class ClipboardSource: ContentSource {
     let type: ContentSourceType = .clipboard
     
     private let history: History = History.shared      // existing model
+    @ObservationIgnored private var cachedItems: [ContentItem] = []
+    @ObservationIgnored private var cachedVersion: Int = -1
     var isMonitoring: Bool { true }                    // handled by Clipboard itself
     var searchQuery: String {
         get { history.searchQuery }
@@ -16,35 +18,39 @@ final class ClipboardSource: ContentSource {
     }
     
     var items: [ContentItem] {
-        // Map HistoryItemDecorator -> ContentItem
-        history.items.map { decorator in
-            // Get UTI for file URLs to enable proper file type badges
-            let uniformTypeIdentifier: String? = {
-                if let fileURL = decorator.item.fileURLs.first,
-                   let resourceValues = try? fileURL.resourceValues(forKeys: [.contentTypeKey]),
-                   let contentType = resourceValues.contentType {
-                    return contentType.identifier
-                }
-                return nil
-            }()
-            
-            return ContentItem(
-                id: decorator.id,
-                title: decorator.title,
-                timestamp: decorator.item.lastCopiedAt,
-                sourceType: .clipboard,
-                sourceId: id,
-                fileURL: decorator.item.fileURLs.first,
-                imageData: decorator.item.imageData,
-                rtfData: decorator.item.rtfData,
-                htmlData: decorator.item.htmlData,
-                plainText: decorator.item.text,
-                uniformTypeIdentifier: uniformTypeIdentifier,
-                applicationBundleId: decorator.item.application,
-                isSelected: decorator.isSelected,
-                isVisible: decorator.isVisible
-            )
+        let version = history.itemsRevision
+        if version != cachedVersion {
+            cachedItems = history.items.map { decorator in
+                // Get UTI for file URLs to enable proper file type badges
+                let uniformTypeIdentifier: String? = {
+                    if let fileURL = decorator.item.fileURLs.first,
+                       let resourceValues = try? fileURL.resourceValues(forKeys: [.contentTypeKey]),
+                       let contentType = resourceValues.contentType {
+                        return contentType.identifier
+                    }
+                    return nil
+                }()
+                
+                return ContentItem(
+                    id: decorator.id,
+                    title: decorator.title,
+                    timestamp: decorator.item.lastCopiedAt,
+                    sourceType: .clipboard,
+                    sourceId: id,
+                    fileURL: decorator.item.fileURLs.first,
+                    imageData: decorator.item.imageData,
+                    rtfData: decorator.item.rtfData,
+                    htmlData: decorator.item.htmlData,
+                    plainText: decorator.item.text,
+                    uniformTypeIdentifier: uniformTypeIdentifier,
+                    applicationBundleId: decorator.item.application,
+                    isSelected: decorator.isSelected,
+                    isVisible: decorator.isVisible
+                )
+            }
+            cachedVersion = version
         }
+        return cachedItems
     }
     
     func startMonitoring() {

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -781,57 +781,57 @@ extension ContentManager {
         // Combine visible and hidden selected items
         let allItemsIncludingHidden = items + hiddenSelectedItems
 
-        // Index folders by path for fast parent lookup
+        // Index folders and children once to avoid repeated scans when building the result
         var folderByPath: [String: ContentItem] = [:]
+        var childrenByParent: [String: [ContentItem]] = [:]
         folderByPath.reserveCapacity(allItemsIncludingHidden.count)
-        for item in allItemsIncludingHidden where item.isFolder {
-            if let path = item.fileURL?.path { folderByPath[path] = item }
+
+        for item in allItemsIncludingHidden {
+            if item.isFolder, let path = item.fileURL?.path {
+                folderByPath[path] = item
+            }
+            if let parentPath = item.parentPath {
+                childrenByParent[parentPath, default: []].append(item)
+            }
         }
-        
+
         // Determine which parent folders need to be included for display due to selected children
         var neededParentIds: Set<UUID> = []
-        for item in allItemsIncludingHidden {
-            guard selectedItemIds.contains(item.id) else { continue }
-            if let parentPath = item.parentPath, let parent = folderByPath[parentPath] {
+        for item in allItemsIncludingHidden where selectedItemIds.contains(item.id) {
+            if let parentPath = item.parentPath,
+               let parent = folderByPath[parentPath] {
                 neededParentIds.insert(parent.id)
             }
         }
-        
+
         // Build result with hierarchical grouping: parent folders followed by their selected children
         var result: [ContentItem] = []
         result.reserveCapacity(selectedItemIds.count + neededParentIds.count)
         var seen: Set<UUID> = []
 
-        // Process items in hierarchical order: folders followed by their children
         for item in allItemsIncludingHidden {
-            // Add parent folders that need to be shown for context
-            if item.isFolder && neededParentIds.contains(item.id) {
-                if !seen.contains(item.id) {
-                    result.append(item)
-                    seen.insert(item.id)
+            if item.isFolder,
+               neededParentIds.contains(item.id),
+               !seen.contains(item.id) {
+                result.append(item)
+                seen.insert(item.id)
 
-                    // Immediately add children of this folder that are selected
-                    let folderPath = item.fileURL?.path
-                    for childItem in allItemsIncludingHidden {
-                        if selectedItemIds.contains(childItem.id) && 
-                           !seen.contains(childItem.id) && 
-                           childItem.parentPath == folderPath {
-                            result.append(childItem)
-                            seen.insert(childItem.id)
-                        }
+                if let folderPath = item.fileURL?.path,
+                   let children = childrenByParent[folderPath] {
+                    for child in children where selectedItemIds.contains(child.id) && !seen.contains(child.id) {
+                        result.append(child)
+                        seen.insert(child.id)
                     }
                 }
+                continue
             }
-        }
-        
-        // Add any remaining selected items that don't have a parent (e.g., clipboard items)
-        for item in allItemsIncludingHidden {
+
             if selectedItemIds.contains(item.id) && !seen.contains(item.id) {
                 result.append(item)
                 seen.insert(item.id)
             }
         }
-        
+
         return result
     }
 }
@@ -882,3 +882,36 @@ extension ContentManager {
         }
     }
 }
+
+#if DEBUG
+extension ContentManager {
+    func resetForTesting() {
+        sources.values.forEach { $0.stopMonitoring() }
+        sources.removeAll()
+        orderedSourceIds.removeAll()
+        activeSourceId = "clipboard"
+        lastNonPromptsSourceId = "clipboard"
+
+        selectedItemIds.removeAll()
+        exampleItemIds.removeAll()
+        selectionVersion = 0
+        focusedItemId = nil
+        renameActiveItemId = nil
+        pendingRenameItemId = nil
+        promptEditorText = ""
+        isPromptEditorEditing = false
+        enhanceButtonClicked = false
+
+        _allItemsCache.removeAll()
+        _allItemsCacheDirty = true
+        _itemsById.removeAll()
+        _itemsBySource.removeAll()
+        _selectedCache.removeAll()
+        _selectedCacheDirty = true
+        _decoratorCache.removeAll()
+        _decoratorCacheDirty.removeAll()
+        _hiddenSelectedItems.removeAll()
+        _pendingHiddenFetch.removeAll()
+    }
+}
+#endif

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -57,6 +57,9 @@ final class ContentManager {
     @ObservationIgnored private var _hiddenSelectedItems: [UUID: ContentItem] = [:]
     @ObservationIgnored private var _pendingHiddenFetch: Set<UUID> = []
 
+    // Track in-flight descendant selection tasks for collapsed folders
+    @ObservationIgnored private var _descendantSelectionTokens: [String: UUID] = [:]
+
     // Cached descendant metadata so collapsed folders avoid repeated disk scans
     private struct DescendantFileInfo: Sendable {
         let id: UUID
@@ -217,7 +220,7 @@ final class ContentManager {
             exampleItemIds.remove(folderId)
             if children.isEmpty {
                 // Collapsed folder - enumerate and select all descendant files
-                selectAllDescendantFiles(in: folderURL)
+                selectAllDescendantFiles(in: folderURL, folderId: folderId)
             } else {
                 // Expanded folder - select all visible children
                 selectFolderChildren(folderId)
@@ -229,7 +232,7 @@ final class ContentManager {
             exampleItemIds.remove(folderId)
             if children.isEmpty {
                 // Collapsed folder - enumerate and deselect all descendant files
-                deselectAllDescendantFiles(in: folderURL)
+                deselectAllDescendantFiles(in: folderURL, folderId: folderId)
             } else {
                 // Expanded folder - deselect all visible children
                 deselectFolderChildren(folderId)
@@ -249,7 +252,7 @@ final class ContentManager {
 
         if children.isEmpty {
             if let url = folderItem.fileURL {
-                selectAllDescendantFiles(in: url)
+                selectAllDescendantFiles(in: url, folderId: folderId)
             }
             return
         }
@@ -276,7 +279,7 @@ final class ContentManager {
 
         if children.isEmpty {
             if let url = folderItem.fileURL {
-                deselectAllDescendantFiles(in: url)
+                deselectAllDescendantFiles(in: url, folderId: folderId)
             }
             return
         }
@@ -294,25 +297,65 @@ final class ContentManager {
     }
     
     // Helper functions for collapsed folder selection
-    private func selectAllDescendantFiles(in folderURL: URL) {
+    private func selectAllDescendantFiles(in folderURL: URL, folderId: UUID) {
+        let token = registerDescendantSelectionTask(for: folderURL)
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self else { return }
             let descendants = self.descendantFiles(at: folderURL)
-            await self.applyDescendantSelection(files: descendants, selecting: true)
-        }
-    }
-    
-    private func deselectAllDescendantFiles(in folderURL: URL) {
-        Task.detached(priority: .userInitiated) { [weak self] in
-            guard let self else { return }
-            let descendants = self.descendantFiles(at: folderURL)
-            await self.applyDescendantSelection(files: descendants, selecting: false)
+            await self.applyDescendantSelection(
+                files: descendants,
+                selecting: true,
+                folderId: folderId,
+                folderURL: folderURL,
+                token: token
+            )
         }
     }
 
+    private func deselectAllDescendantFiles(in folderURL: URL, folderId: UUID) {
+        let token = registerDescendantSelectionTask(for: folderURL)
+        Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            let descendants = self.descendantFiles(at: folderURL)
+            await self.applyDescendantSelection(
+                files: descendants,
+                selecting: false,
+                folderId: folderId,
+                folderURL: folderURL,
+                token: token
+            )
+        }
+    }
+
+    private func registerDescendantSelectionTask(for folderURL: URL) -> UUID {
+        let token = UUID()
+        _descendantSelectionTokens[descendantSelectionTokenKey(for: folderURL)] = token
+        return token
+    }
+
+    private func descendantSelectionTokenKey(for folderURL: URL) -> String {
+        folderURL.standardizedFileURL.path
+    }
+
     @MainActor
-    private func applyDescendantSelection(files: [DescendantFileInfo], selecting: Bool) {
+    private func applyDescendantSelection(
+        files: [DescendantFileInfo],
+        selecting: Bool,
+        folderId: UUID,
+        folderURL: URL,
+        token: UUID
+    ) {
+        let tokenKey = descendantSelectionTokenKey(for: folderURL)
+        guard _descendantSelectionTokens[tokenKey] == token else { return }
+        _descendantSelectionTokens.removeValue(forKey: tokenKey)
+
         guard !files.isEmpty else { return }
+
+        if selecting {
+            guard selectedItemIds.contains(folderId) else { return }
+        } else {
+            guard !selectedItemIds.contains(folderId) else { return }
+        }
 
         if selecting {
             let ids = Set(files.map(\.id))

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -38,6 +38,12 @@ final class ContentManager {
     var isPromptEditorEditing: Bool = false
     var enhanceButtonClicked: Bool = false // Flag to prevent editor exit on enhance
     
+    // Cache for flattened content items to avoid repeated traversals
+    @ObservationIgnored private var _allItemsCache: [ContentItem] = []
+    @ObservationIgnored private var _allItemsCacheDirty: Bool = true
+    @ObservationIgnored private var _itemsById: [UUID: ContentItem] = [:]
+    @ObservationIgnored private var _itemsBySource: [String: [ContentItem]] = [:]
+
     // Cache for selected items to avoid repeated full scans and sorts
     @ObservationIgnored private var _selectedCache: [ContentItem] = []
     @ObservationIgnored private var _selectedCacheDirty: Bool = true
@@ -72,11 +78,12 @@ final class ContentManager {
     }
     
     var focusedContentItem: ContentItem? {
-        allItems.first { $0.id == focusedItemId }
+        item(for: focusedItemId)
     }
     
     var allItems: [ContentItem] {
-        orderedSourceIds.flatMap { sources[$0]?.items ?? [] }
+        rebuildItemCachesIfNeeded()
+        return _allItemsCache
     }
     
     // Computed views
@@ -84,11 +91,43 @@ final class ContentManager {
         guard let src = sources[activeSourceId] else { return [] }
         return src.items
     }
+
+    private func rebuildItemCachesIfNeeded() {
+        if !_allItemsCacheDirty { return }
+
+        var flattened: [ContentItem] = []
+        var byId: [UUID: ContentItem] = [:]
+        var bySource: [String: [ContentItem]] = [:]
+
+        for sourceId in orderedSourceIds {
+            guard let items = sources[sourceId]?.items else { continue }
+            flattened.append(contentsOf: items)
+            bySource[sourceId] = items
+            for item in items where byId[item.id] == nil {
+                byId[item.id] = item
+            }
+        }
+
+        _allItemsCache = flattened
+        _itemsById = byId
+        _itemsBySource = bySource
+        _allItemsCacheDirty = false
+    }
+
+    func markItemsDirty() {
+        _allItemsCacheDirty = true
+    }
+
+    func item(for id: UUID?) -> ContentItem? {
+        guard let id else { return nil }
+        rebuildItemCachesIfNeeded()
+        return _itemsById[id]
+    }
     
     // Selection management
     func toggleSelection(_ id: UUID) {
         // Check if this is a folder and handle specially
-        if let folderItem = allItems.first(where: { $0.id == id }), folderItem.isFolder {
+        if let folderItem = item(for: id), folderItem.isFolder {
             toggleFolderSelection(id)
         } else {
             // Regular item selection
@@ -107,11 +146,11 @@ final class ContentManager {
     }
     
     private func toggleFolderSelection(_ folderId: UUID) {
-        guard let folderItem = allItems.first(where: { $0.id == folderId }),
-              folderItem.isFolder,
-              let folderPath = folderItem.fileURL?.path,
-              let folderURL = folderItem.fileURL else { return }
-        
+        guard let folderItem = item(for: folderId),
+             folderItem.isFolder,
+             let folderPath = folderItem.fileURL?.path,
+             let folderURL = folderItem.fileURL else { return }
+
         let children = allItems.filter { $0.parentPath == folderPath }
         let currentState = getFolderSelectionState(folderId)
         
@@ -140,12 +179,14 @@ final class ContentManager {
     }
     
     func selectFolderChildren(_ folderId: UUID) {
-        guard let folderItem = allItems.first(where: { $0.id == folderId }),
-              folderItem.isFolder,
-              let folderPath = folderItem.fileURL?.path else { return }
+        guard let folderItem = item(for: folderId),
+             folderItem.isFolder,
+             let folderPath = folderItem.fileURL?.path else { return }
         
+        guard let sourceItems = _itemsBySource[folderItem.sourceId] else { return }
+
         // Select all visible children of this folder (but not the folder itself)
-        for item in allItems {
+        for item in sourceItems {
             if item.parentPath == folderPath {
                 if item.isFolder {
                     // Recursively select nested folder children
@@ -162,12 +203,14 @@ final class ContentManager {
     }
     
     func deselectFolderChildren(_ folderId: UUID) {
-        guard let folderItem = allItems.first(where: { $0.id == folderId }),
-              folderItem.isFolder,
-              let folderPath = folderItem.fileURL?.path else { return }
+        guard let folderItem = item(for: folderId),
+             folderItem.isFolder,
+             let folderPath = folderItem.fileURL?.path else { return }
         
+        guard let sourceItems = _itemsBySource[folderItem.sourceId] else { return }
+
         // Deselect all children of this folder (but not the folder itself)
-        for item in allItems {
+        for item in sourceItems {
             if item.parentPath == folderPath {
                 if item.isFolder {
                     // Recursively deselect nested folder children
@@ -185,22 +228,36 @@ final class ContentManager {
     
     // Helper functions for collapsed folder selection
     private func selectAllDescendantFiles(in folderURL: URL) {
-        let descendantURLs = enumerateDescendantFiles(at: folderURL)
-        for url in descendantURLs {
-            let fileId = stableUUID(for: url)
-            selectedItemIds.insert(fileId)
-            // Files are selected as context by default (not examples)
-            exampleItemIds.remove(fileId)
+        Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            let descendantURLs = self.enumerateDescendantFiles(at: folderURL)
+            await self.applyDescendantSelection(urls: descendantURLs, selecting: true)
         }
     }
     
     private func deselectAllDescendantFiles(in folderURL: URL) {
-        let descendantURLs = enumerateDescendantFiles(at: folderURL)
-        for url in descendantURLs {
-            let fileId = stableUUID(for: url)
-            selectedItemIds.remove(fileId)
-            exampleItemIds.remove(fileId)
+        Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            let descendantURLs = self.enumerateDescendantFiles(at: folderURL)
+            await self.applyDescendantSelection(urls: descendantURLs, selecting: false)
         }
+    }
+
+    @MainActor
+    private func applyDescendantSelection(urls: [URL], selecting: Bool) {
+        guard !urls.isEmpty else { return }
+
+        for url in urls {
+            let fileId = stableUUID(for: url)
+            if selecting {
+                selectedItemIds.insert(fileId)
+                exampleItemIds.remove(fileId)
+            } else {
+                selectedItemIds.remove(fileId)
+                exampleItemIds.remove(fileId)
+            }
+        }
+        markSelectedDirty()
     }
     
     func clearSelection() {
@@ -223,7 +280,8 @@ final class ContentManager {
         guard item.sourceType == .folder, let itemPath = item.fileURL?.path else { return false }
         // Any selected folder that is an ancestor of this item implies effective selection
         for fid in selectedItemIds {
-            if let folder = allItems.first(where: { $0.id == fid && $0.isFolder }),
+            if let folder = self.item(for: fid),
+               folder.isFolder,
                let folderPath = folder.fileURL?.path,
                itemPath.hasPrefix(folderPath.hasSuffix("/") ? folderPath : folderPath + "/") {
                 // Ensure not the folder itself
@@ -234,12 +292,14 @@ final class ContentManager {
     }
     
     func getFolderSelectionState(_ folderId: UUID) -> FolderSelectionState {
-        guard let folderItem = allItems.first(where: { $0.id == folderId }),
+        guard let folderItem = item(for: folderId),
               folderItem.isFolder,
               let folderPath = folderItem.fileURL?.path else { return .none }
 
+        guard let sourceItems = _itemsBySource[folderItem.sourceId] else { return .none }
+
         // Get all visible children of this folder
-        let children = allItems.filter { $0.parentPath == folderPath }
+        let children = sourceItems.filter { $0.parentPath == folderPath }
 
         // If folder is collapsed (no visible children), compute state from real descendants on disk
         if children.isEmpty {
@@ -318,7 +378,7 @@ final class ContentManager {
     
     private func syncClipboardSelection(_ id: UUID) {
         // If this is a clipboard item, sync with History
-        if let item = allItems.first(where: { $0.id == id }),
+        if let item = item(for: id),
            item.sourceType == .clipboard {
             if let historyItem = History.shared.items.first(where: { $0.id == id }) {
                 historyItem.isSelected = selectedItemIds.contains(id)
@@ -332,7 +392,9 @@ final class ContentManager {
         if !orderedSourceIds.contains(source.id) {
             orderedSourceIds.append(source.id)
         }
-        
+
+        markItemsDirty()
+
         // Sync initial selection state for clipboard items
         if source is ClipboardSource {
             for item in History.shared.items where item.isSelected {
@@ -356,6 +418,7 @@ final class ContentManager {
         // Remove from storage
         sources.removeValue(forKey: sourceId)
         orderedSourceIds.removeAll { $0 == sourceId }
+        markItemsDirty()
         
         // Clear any selections from this source
         let sourceItems = source.items
@@ -574,7 +637,7 @@ final class ContentManager {
     }
     
     // File enumeration helpers
-    private func enumerateDescendantFiles(at baseURL: URL) -> [URL] {
+    nonisolated private func enumerateDescendantFiles(at baseURL: URL) -> [URL] {
         var results: [URL] = []
         let fm = FileManager.default
         if let enumerator = fm.enumerator(at: baseURL, includingPropertiesForKeys: [.isDirectoryKey, .contentTypeKey], options: [.skipsHiddenFiles]) {
@@ -602,20 +665,20 @@ final class ContentManager {
         return false
     }
     
-    func stableUUID(for url: URL) -> UUID {
+    nonisolated func stableUUID(for url: URL) -> UUID {
         let snap = FileIdentity.snapshot(for: url)
         return FileSystemSource.makeStableUUID(identity: snap.identity, fallbackPath: url.absoluteString)
     }
     
     func canToggleExample(_ id: UUID) -> Bool {
         guard selectedItemIds.contains(id),
-              let _ = allItems.first(where: { $0.id == id }) else { return false }
+              item(for: id) != nil else { return false }
         
         return isTextualItem(id)
     }
     
     func isTextualItem(_ id: UUID) -> Bool {
-        guard let item = allItems.first(where: { $0.id == id }) else { return false }
+        guard let item = item(for: id) else { return false }
         
         if item.isFolder {
             // Allow folder examples only if all descendant files are textual and there is at least one file
@@ -681,14 +744,14 @@ extension ContentManager {
         // For folder sources, we need to handle collapsed folders with selected children
         var hiddenSelectedItems: [ContentItem] = []
 
-        // Check each source for selected items that might be hidden (files in collapsed folders)
-        for sourceId in orderedSourceIds {
-            guard let source = sources[sourceId] as? FileSystemSource else { continue }
-            // Get all selected IDs that aren't visible in current items
-            let visibleIds = Set(items.map { $0.id })
-            let hiddenSelectedIds = selectedItemIds.subtracting(visibleIds)
+        let visibleIds = Set(items.map { $0.id })
+        let hiddenSelectedIds = selectedItemIds.subtracting(visibleIds)
 
-            if !hiddenSelectedIds.isEmpty {
+        if !hiddenSelectedIds.isEmpty {
+            // Check each source for selected items that might be hidden (files in collapsed folders)
+            for sourceId in orderedSourceIds {
+                guard let source = sources[sourceId] as? FileSystemSource else { continue }
+
                 // Scan the filesystem to find these hidden selected files
                 let foundItems = source.findItemsById(hiddenSelectedIds)
                 hiddenSelectedItems.append(contentsOf: foundItems.filter { !$0.isFolder })

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Foundation
 import UniformTypeIdentifiers
 import Observation
 
@@ -55,7 +56,18 @@ final class ContentManager {
     // Cache for hidden selections fetched off the main thread
     @ObservationIgnored private var _hiddenSelectedItems: [UUID: ContentItem] = [:]
     @ObservationIgnored private var _pendingHiddenFetch: Set<UUID> = []
-    
+
+    // Cached descendant metadata so collapsed folders avoid repeated disk scans
+    private struct DescendantFileInfo: Sendable {
+        let id: UUID
+        let isText: Bool
+    }
+
+    private struct DescendantCacheEntry: Sendable {
+        let files: [DescendantFileInfo]
+        let directoryModificationDate: Date
+    }
+
     // (Removed) Aggregated display version tracking; Aggregated now shows only pasteable items
     
     var selectedItems: [ContentItem] {
@@ -128,7 +140,10 @@ final class ContentManager {
     func item(for id: UUID?) -> ContentItem? {
         guard let id else { return nil }
         rebuildItemCachesIfNeeded()
-        return _itemsById[id]
+        if let visible = _itemsById[id] {
+            return visible
+        }
+        return _hiddenSelectedItems[id]
     }
     
     // Selection management
@@ -158,12 +173,14 @@ final class ContentManager {
              let folderPath = folderItem.fileURL?.path,
              let folderURL = folderItem.fileURL else { return }
 
-        let children = allItems.filter { $0.parentPath == folderPath }
+        let children = visibleChildItems(of: folderItem)
         let currentState = getFolderSelectionState(folderId)
         
         switch currentState {
         case .none:
             // No children selected - select everything
+            selectedItemIds.insert(folderId)
+            exampleItemIds.remove(folderId)
             if children.isEmpty {
                 // Collapsed folder - enumerate and select all descendant files
                 selectAllDescendantFiles(in: folderURL)
@@ -174,6 +191,8 @@ final class ContentManager {
             
         case .partial, .all:
             // Some or all children selected - deselect everything
+            selectedItemIds.remove(folderId)
+            exampleItemIds.remove(folderId)
             if children.isEmpty {
                 // Collapsed folder - enumerate and deselect all descendant files
                 deselectAllDescendantFiles(in: folderURL)
@@ -187,23 +206,26 @@ final class ContentManager {
     
     func selectFolderChildren(_ folderId: UUID) {
         guard let folderItem = item(for: folderId),
-             folderItem.isFolder,
-             let folderPath = folderItem.fileURL?.path else { return }
+             folderItem.isFolder else { return }
         
-        guard let sourceItems = _itemsBySource[folderItem.sourceId] else { return }
+        let children = visibleChildItems(of: folderItem)
 
-        // Select all visible children of this folder (but not the folder itself)
-        for item in sourceItems {
-            if item.parentPath == folderPath {
-                if item.isFolder {
-                    // Recursively select nested folder children
-                    selectFolderChildren(item.id)
-                } else {
-                    // Only add file IDs to selectedItemIds, not folder IDs
-                    selectedItemIds.insert(item.id)
-                    // Children are selected as context by default (not examples)
-                    exampleItemIds.remove(item.id)
-                }
+        selectedItemIds.insert(folderId)
+        exampleItemIds.remove(folderId)
+
+        if children.isEmpty {
+            if let url = folderItem.fileURL {
+                selectAllDescendantFiles(in: url)
+            }
+            return
+        }
+
+        for item in children {
+            if item.isFolder {
+                selectFolderChildren(item.id)
+            } else {
+                selectedItemIds.insert(item.id)
+                exampleItemIds.remove(item.id)
             }
         }
         markSelectedDirty()
@@ -211,23 +233,27 @@ final class ContentManager {
     
     func deselectFolderChildren(_ folderId: UUID) {
         guard let folderItem = item(for: folderId),
-             folderItem.isFolder,
-             let folderPath = folderItem.fileURL?.path else { return }
-        
-        guard let sourceItems = _itemsBySource[folderItem.sourceId] else { return }
+             folderItem.isFolder else { return }
+
+        let children = visibleChildItems(of: folderItem)
+
+        selectedItemIds.remove(folderId)
+        exampleItemIds.remove(folderId)
+
+        if children.isEmpty {
+            if let url = folderItem.fileURL {
+                deselectAllDescendantFiles(in: url)
+            }
+            return
+        }
 
         // Deselect all children of this folder (but not the folder itself)
-        for item in sourceItems {
-            if item.parentPath == folderPath {
-                if item.isFolder {
-                    // Recursively deselect nested folder children
-                    deselectFolderChildren(item.id)
-                } else {
-                    // Only remove file IDs from selectedItemIds, not folder IDs
-                    selectedItemIds.remove(item.id)
-                    // Remove example flag when deselecting children
-                    exampleItemIds.remove(item.id)
-                }
+        for item in children {
+            if item.isFolder {
+                deselectFolderChildren(item.id)
+            } else {
+                selectedItemIds.remove(item.id)
+                exampleItemIds.remove(item.id)
             }
         }
         markSelectedDirty()
@@ -237,31 +263,42 @@ final class ContentManager {
     private func selectAllDescendantFiles(in folderURL: URL) {
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self else { return }
-            let descendantURLs = self.enumerateDescendantFiles(at: folderURL)
-            await self.applyDescendantSelection(urls: descendantURLs, selecting: true)
+            let descendants = self.descendantFiles(at: folderURL)
+            await self.applyDescendantSelection(files: descendants, selecting: true)
         }
     }
     
     private func deselectAllDescendantFiles(in folderURL: URL) {
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self else { return }
-            let descendantURLs = self.enumerateDescendantFiles(at: folderURL)
-            await self.applyDescendantSelection(urls: descendantURLs, selecting: false)
+            let descendants = self.descendantFiles(at: folderURL)
+            await self.applyDescendantSelection(files: descendants, selecting: false)
         }
     }
 
     @MainActor
-    private func applyDescendantSelection(urls: [URL], selecting: Bool) {
-        guard !urls.isEmpty else { return }
+    private func applyDescendantSelection(files: [DescendantFileInfo], selecting: Bool) {
+        guard !files.isEmpty else { return }
 
-        for url in urls {
-            let fileId = stableUUID(for: url)
+        if selecting {
+            let ids = Set(files.map(\.id))
+            if !ids.isEmpty {
+                scheduleHiddenSelectionPrefetch(for: ids)
+            }
+        } else {
+            for file in files {
+                _hiddenSelectedItems.removeValue(forKey: file.id)
+                _pendingHiddenFetch.remove(file.id)
+            }
+        }
+
+        for file in files {
             if selecting {
-                selectedItemIds.insert(fileId)
-                exampleItemIds.remove(fileId)
+                selectedItemIds.insert(file.id)
+                exampleItemIds.remove(file.id)
             } else {
-                selectedItemIds.remove(fileId)
-                exampleItemIds.remove(fileId)
+                selectedItemIds.remove(file.id)
+                exampleItemIds.remove(file.id)
             }
         }
         markSelectedDirty()
@@ -312,14 +349,13 @@ final class ContentManager {
 
         // If folder is collapsed (no visible children), compute state from real descendants on disk
         if children.isEmpty {
-            let urls = enumerateDescendantFiles(at: URL(fileURLWithPath: folderPath))
-            guard !urls.isEmpty else { return .none }
-            let selectedCount = urls.reduce(0) { acc, url in
-                let id = stableUUID(for: url)
-                return acc + (selectedItemIds.contains(id) ? 1 : 0)
+            let descendants = descendantFiles(at: URL(fileURLWithPath: folderPath))
+            guard !descendants.isEmpty else { return .none }
+            let selectedCount = descendants.reduce(0) { acc, file in
+                acc + (selectedItemIds.contains(file.id) ? 1 : 0)
             }
             if selectedCount == 0 { return .none }
-            if selectedCount == urls.count { return .all }
+            if selectedCount == descendants.count { return .all }
             return .partial
         }
         
@@ -460,11 +496,13 @@ final class ContentManager {
         if source.type == .folder {
             // Prefer obtaining the exact URL from FileSystemSource
             if let fs = source as? FileSystemSource {
+                invalidateDescendantCache(under: fs.folderURL.path)
                 Bookmarks.remove(url: fs.folderURL)
             } else if sourceId.hasPrefix("folder:") {
                 // Fallback: extract folder URL from identifier pattern
                 let folderPath = String(sourceId.dropFirst("folder:".count))
                 let folderURL = URL(fileURLWithPath: folderPath)
+                invalidateDescendantCache(under: folderPath)
                 Bookmarks.remove(url: folderURL)
             }
         }
@@ -524,6 +562,10 @@ final class ContentManager {
     // Mark a source's decorator cache as dirty (needs refresh)
     func markDecoratorsNeedRefresh(for sourceId: String) {
         _decoratorCacheDirty.insert(sourceId)
+    }
+
+    func invalidateDescendantCache(under path: String? = nil) {
+        removeDescendantEntries(withPrefix: path)
     }
     
     // Clear decorator cache for a source (when source is removed)
@@ -623,6 +665,8 @@ final class ContentManager {
                 let childIDs = descendantTextItemIDs(for: item)
                 for cid in childIDs {
                     exampleItemIds.remove(cid)
+                    _hiddenSelectedItems.removeValue(forKey: cid)
+                    _pendingHiddenFetch.remove(cid)
                 }
             }
         } else {
@@ -635,6 +679,9 @@ final class ContentManager {
                     selectedItemIds.insert(cid)
                     exampleItemIds.insert(cid)
                 }
+                if !childIDs.isEmpty {
+                    scheduleHiddenSelectionPrefetch(for: Set(childIDs))
+                }
             }
         }
         markSelectedDirty()
@@ -643,43 +690,91 @@ final class ContentManager {
     // Collect all textual descendant file UUIDs for a folder item by scanning the filesystem
     private func descendantTextItemIDs(for folder: ContentItem) -> [UUID] {
         guard folder.isFolder, let baseURL = folder.fileURL else { return [] }
-        let fileURLs = self.enumerateDescendantFiles(at: baseURL)
-        var ids: [UUID] = []
-        for url in fileURLs {
-            if isTextURL(url) {
-                let id = stableUUID(for: url)
-                ids.append(id)
+        let files = descendantFiles(at: baseURL)
+        return files.filter { $0.isText }.map { $0.id }
+    }
+
+    private func visibleChildItems(of folder: ContentItem) -> [ContentItem] {
+        rebuildItemCachesIfNeeded()
+        guard let sourceItems = _itemsBySource[folder.sourceId],
+              let startIndex = sourceItems.firstIndex(where: { $0.id == folder.id }) else { return [] }
+
+        let childDepth = folder.depth + 1
+        var results: [ContentItem] = []
+        var index = startIndex + 1
+
+        while index < sourceItems.count {
+            let item = sourceItems[index]
+            if item.depth <= folder.depth { break }
+            if item.depth == childDepth {
+                results.append(item)
             }
+            index += 1
         }
-        return ids
+        return results
     }
     
     // File enumeration helpers
-    nonisolated private func enumerateDescendantFiles(at baseURL: URL) -> [URL] {
-        var results: [URL] = []
+    nonisolated private func descendantFiles(at baseURL: URL) -> [DescendantFileInfo] {
+        let folderPath = baseURL.path
+        let directoryModDate = (try? baseURL.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+
+        if let cached = cachedDescendantEntry(for: folderPath), cached.directoryModificationDate == directoryModDate {
+            return cached.files
+        }
+
+        var results: [DescendantFileInfo] = []
         let fm = FileManager.default
         if let enumerator = fm.enumerator(at: baseURL, includingPropertiesForKeys: [.isDirectoryKey, .contentTypeKey], options: [.skipsHiddenFiles]) {
             for case let url as URL in enumerator {
                 do {
-                    let vals = try url.resourceValues(forKeys: [.isDirectoryKey])
-                    if vals.isDirectory == true { continue }
-                    results.append(url)
+                    let values = try url.resourceValues(forKeys: [.isDirectoryKey, .contentTypeKey])
+                    if values.isDirectory == true { continue }
+                    let type = values.contentType ?? FileSystemSource.resolvedType(for: url)
+                    let info = DescendantFileInfo(
+                        id: stableUUID(for: url),
+                        isText: isTextType(type)
+                    )
+                    results.append(info)
                 } catch {
                     continue
                 }
             }
         }
+
+        storeDescendantEntry(
+            DescendantCacheEntry(files: results, directoryModificationDate: directoryModDate),
+            for: folderPath
+        )
         return results
     }
-    
-    private func isTextURL(_ url: URL) -> Bool {
-        let type = FileSystemSource.resolvedType(for: url)
-        if type?.conforms(to: .text) == true { return true }
+
+    nonisolated private func cachedDescendantEntry(for path: String) -> DescendantCacheEntry? {
+        DescendantCacheStore.shared.entry(for: path)
+    }
+
+    nonisolated private func storeDescendantEntry(_ entry: DescendantCacheEntry, for path: String) {
+        DescendantCacheStore.shared.store(entry, for: path)
+    }
+
+    nonisolated private func removeDescendantEntries(withPrefix prefix: String?) {
+        guard let prefix, !prefix.isEmpty else {
+            DescendantCacheStore.shared.removeAll()
+            return
+        }
+
+        DescendantCacheStore.shared.remove(prefix: prefix)
+    }
+
+    nonisolated private func isTextType(_ type: UTType?) -> Bool {
+        guard let type else { return false }
+        if type.conforms(to: .text) { return true }
         if type == .rtf || type == .rtfd || type == .html { return true }
-        // Markdown special cases
-        if type?.identifier == "net.daringfireball.markdown" ||
-           type?.identifier == "public.markdown" ||
-           type?.preferredFilenameExtension == "md" { return true }
+        if type.identifier == "net.daringfireball.markdown" ||
+            type.identifier == "public.markdown" ||
+            type.preferredFilenameExtension == "md" {
+            return true
+        }
         return false
     }
     
@@ -701,10 +796,9 @@ final class ContentManager {
         if item.isFolder {
             // Allow folder examples only if all descendant files are textual and there is at least one file
             guard let baseURL = item.fileURL else { return false }
-            let files = enumerateDescendantFiles(at: baseURL)
-            let textual = files.filter { isTextURL($0) }
+            let files = descendantFiles(at: baseURL)
             guard !files.isEmpty else { return false }
-            return files.count == textual.count
+            return files.allSatisfy { $0.isText }
         }
         
         // Disallow media or non-text files as examples
@@ -883,6 +977,39 @@ extension ContentManager {
     }
 }
 
+extension ContentManager {
+    private final class DescendantCacheStore: @unchecked Sendable {
+        static let shared = DescendantCacheStore()
+
+        private let lock = NSLock()
+        private var storage: [String: DescendantCacheEntry] = [:]
+
+        func entry(for path: String) -> DescendantCacheEntry? {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage[path]
+        }
+
+        func store(_ entry: DescendantCacheEntry, for path: String) {
+            lock.lock()
+            storage[path] = entry
+            lock.unlock()
+        }
+
+        func removeAll() {
+            lock.lock()
+            storage.removeAll()
+            lock.unlock()
+        }
+
+        func remove(prefix: String) {
+            lock.lock()
+            storage = storage.filter { !$0.key.hasPrefix(prefix) }
+            lock.unlock()
+        }
+    }
+}
+
 #if DEBUG
 extension ContentManager {
     func resetForTesting() {
@@ -912,6 +1039,7 @@ extension ContentManager {
         _decoratorCacheDirty.removeAll()
         _hiddenSelectedItems.removeAll()
         _pendingHiddenFetch.removeAll()
+        removeDescendantEntries(withPrefix: nil)
     }
 }
 #endif

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -597,7 +597,7 @@ final class ContentManager {
     func toggleExample(_ id: UUID) {
         // Allow toggling example state for any textual items (no need to be selected as context)
         guard isTextualItem(id) else { return }
-        guard let item = allItems.first(where: { $0.id == id }) else { return }
+        guard let item = item(for: id) else { return }
         if exampleItemIds.contains(id) {
             // Turning OFF example: clear on folder and its descendants
             exampleItemIds.remove(id)

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -53,6 +53,9 @@ final class ContentManager {
     @ObservationIgnored private var _decoratorCache: [String: [UUID: UniversalItemDecorator]] = [:] // sourceId -> [itemId -> decorator]
     @ObservationIgnored private var _decoratorCacheDirty: Set<String> = [] // sourceIds that need cache refresh
 
+    // Manual deselection tracking for folder descendants
+    @ObservationIgnored private var _folderSelectionExclusions: [UUID: DeselectionOverride] = [:]
+
     // Cache for hidden selections fetched off the main thread
     @ObservationIgnored private var _hiddenSelectedItems: [UUID: ContentItem] = [:]
     @ObservationIgnored private var _pendingHiddenFetch: Set<UUID> = []
@@ -63,12 +66,18 @@ final class ContentManager {
     // Cached descendant metadata so collapsed folders avoid repeated disk scans
     private struct DescendantFileInfo: Sendable {
         let id: UUID
+        let path: String
         let isText: Bool
     }
 
     private struct DescendantCacheEntry: Sendable {
         let files: [DescendantFileInfo]
         let directoryModificationDate: Date
+    }
+
+    private struct DeselectionOverride: Sendable {
+        let path: String
+        let appliesToDescendants: Bool
     }
 
     // (Removed) Aggregated display version tracking; Aggregated now shows only pasteable items
@@ -198,6 +207,9 @@ final class ContentManager {
             } else {
                 selectedItemIds.insert(id)
             }
+            if let toggledItem = item(for: id) {
+                updateFolderDeselectionOverride(for: toggledItem, deselected: wasSelected)
+            }
             // Bridge to clipboard selection if needed
             syncClipboardSelection(id)
         }
@@ -206,9 +218,8 @@ final class ContentManager {
     
     private func toggleFolderSelection(_ folderId: UUID) {
         guard let folderItem = item(for: folderId),
-             folderItem.isFolder,
-             let folderPath = folderItem.fileURL?.path,
-             let folderURL = folderItem.fileURL else { return }
+              folderItem.isFolder,
+              let folderURL = folderItem.fileURL else { return }
 
         let children = visibleChildItems(of: folderItem)
         let currentState = getFolderSelectionState(folderId)
@@ -216,8 +227,10 @@ final class ContentManager {
         switch currentState {
         case .none:
             // No children selected - select everything
+            removeDeselectionOverrides(inSubtreeOf: folderItem)
             selectedItemIds.insert(folderId)
             exampleItemIds.remove(folderId)
+            updateFolderDeselectionOverride(for: folderItem, deselected: false)
             if children.isEmpty {
                 // Collapsed folder - enumerate and select all descendant files
                 selectAllDescendantFiles(in: folderURL, folderId: folderId)
@@ -230,6 +243,7 @@ final class ContentManager {
             // Some or all children selected - deselect everything
             selectedItemIds.remove(folderId)
             exampleItemIds.remove(folderId)
+            updateFolderDeselectionOverride(for: folderItem, deselected: true)
             if children.isEmpty {
                 // Collapsed folder - enumerate and deselect all descendant files
                 deselectAllDescendantFiles(in: folderURL, folderId: folderId)
@@ -243,12 +257,13 @@ final class ContentManager {
     
     func selectFolderChildren(_ folderId: UUID) {
         guard let folderItem = item(for: folderId),
-             folderItem.isFolder else { return }
+              folderItem.isFolder else { return }
         
         let children = visibleChildItems(of: folderItem)
 
         selectedItemIds.insert(folderId)
         exampleItemIds.remove(folderId)
+        updateFolderDeselectionOverride(for: folderItem, deselected: false)
 
         if children.isEmpty {
             if let url = folderItem.fileURL {
@@ -258,11 +273,13 @@ final class ContentManager {
         }
 
         for item in children {
+            guard !isUnderDeselectionOverride(item) else { continue }
             if item.isFolder {
                 selectFolderChildren(item.id)
             } else {
                 selectedItemIds.insert(item.id)
                 exampleItemIds.remove(item.id)
+                updateFolderDeselectionOverride(for: item, deselected: false)
             }
         }
         markSelectedDirty()
@@ -270,12 +287,13 @@ final class ContentManager {
     
     func deselectFolderChildren(_ folderId: UUID) {
         guard let folderItem = item(for: folderId),
-             folderItem.isFolder else { return }
+              folderItem.isFolder else { return }
 
         let children = visibleChildItems(of: folderItem)
 
         selectedItemIds.remove(folderId)
         exampleItemIds.remove(folderId)
+        updateFolderDeselectionOverride(for: folderItem, deselected: true)
 
         if children.isEmpty {
             if let url = folderItem.fileURL {
@@ -291,9 +309,93 @@ final class ContentManager {
             } else {
                 selectedItemIds.remove(item.id)
                 exampleItemIds.remove(item.id)
+                updateFolderDeselectionOverride(for: item, deselected: true)
             }
         }
         markSelectedDirty()
+    }
+
+    private func updateFolderDeselectionOverride(for item: ContentItem, deselected: Bool) {
+        guard item.sourceType == .folder else {
+            _folderSelectionExclusions.removeValue(forKey: item.id)
+            return
+        }
+        guard let normalized = normalizedPath(for: item) else {
+            _folderSelectionExclusions.removeValue(forKey: item.id)
+            return
+        }
+
+        if deselected {
+            if hasSelectedFolderAncestor(for: item) {
+                _folderSelectionExclusions[item.id] = DeselectionOverride(
+                    path: normalized,
+                    appliesToDescendants: item.isFolder
+                )
+            } else {
+                _folderSelectionExclusions.removeValue(forKey: item.id)
+            }
+        } else {
+            _folderSelectionExclusions.removeValue(forKey: item.id)
+        }
+    }
+
+    private func removeDeselectionOverrides(inSubtreeOf folder: ContentItem) {
+        guard folder.sourceType == .folder,
+              let basePath = normalizedPath(for: folder),
+              !_folderSelectionExclusions.isEmpty else { return }
+
+        var toRemove: [UUID] = []
+        for (id, override) in _folderSelectionExclusions where override.path.hasPrefix(basePath) {
+            toRemove.append(id)
+        }
+
+        for id in toRemove {
+            _folderSelectionExclusions.removeValue(forKey: id)
+        }
+    }
+
+    private func isUnderDeselectionOverride(_ item: ContentItem) -> Bool {
+        guard item.sourceType == .folder,
+              let path = normalizedPath(for: item) else { return false }
+        if _folderSelectionExclusions[item.id] != nil { return true }
+        return hasDeselectionOverride(forPath: path, excluding: item.id)
+    }
+
+    private func hasDeselectionOverride(forPath path: String, excluding id: UUID? = nil) -> Bool {
+        guard !_folderSelectionExclusions.isEmpty else { return false }
+        for (key, override) in _folderSelectionExclusions {
+            if let id, key == id { continue }
+            if override.appliesToDescendants {
+                if path.hasPrefix(override.path) { return true }
+            } else if path == override.path {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func hasSelectedFolderAncestor(for item: ContentItem) -> Bool {
+        guard item.sourceType == .folder,
+              let itemPath = normalizedPath(for: item) else { return false }
+        for fid in selectedItemIds where fid != item.id {
+            guard let ancestor = self.item(for: fid),
+                  ancestor.isFolder,
+                  ancestor.sourceType == .folder,
+                  let ancestorPath = normalizedPath(for: ancestor) else { continue }
+            if itemPath.hasPrefix(ancestorPath) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func normalizedPath(for item: ContentItem) -> String? {
+        guard let path = item.fileURL?.path else { return nil }
+        return item.isFolder ? normalizedFolderPath(path) : path
+    }
+
+    private func normalizedFolderPath(_ path: String) -> String {
+        path.hasSuffix("/") ? path : path + "/"
     }
     
     // Helper functions for collapsed folder selection
@@ -357,8 +459,15 @@ final class ContentManager {
             guard !selectedItemIds.contains(folderId) else { return }
         }
 
+        let processedFiles: [DescendantFileInfo]
         if selecting {
-            let ids = Set(files.map(\.id))
+            processedFiles = files.filter { !hasDeselectionOverride(forPath: $0.path) }
+        } else {
+            processedFiles = files
+        }
+
+        if selecting {
+            let ids = Set(processedFiles.map(\.id))
             if !ids.isEmpty {
                 scheduleHiddenSelectionPrefetch(for: ids)
             }
@@ -369,10 +478,11 @@ final class ContentManager {
             }
         }
 
-        for file in files {
+        for file in processedFiles {
             if selecting {
                 selectedItemIds.insert(file.id)
                 exampleItemIds.remove(file.id)
+                _folderSelectionExclusions.removeValue(forKey: file.id)
             } else {
                 selectedItemIds.remove(file.id)
                 exampleItemIds.remove(file.id)
@@ -380,7 +490,7 @@ final class ContentManager {
         }
         markSelectedDirty()
     }
-    
+
     func clearSelection() {
         selectedItemIds.removeAll()
         exampleItemIds.removeAll()
@@ -390,6 +500,7 @@ final class ContentManager {
         }
         _hiddenSelectedItems.removeAll()
         _pendingHiddenFetch.removeAll()
+        _folderSelectionExclusions.removeAll()
         markSelectedDirty()
     }
     
@@ -400,15 +511,20 @@ final class ContentManager {
     // - It is a file inside any selected folder (use path prefix check)
     func isSelected(effectively item: ContentItem) -> Bool {
         if selectedItemIds.contains(item.id) { return true }
-        guard item.sourceType == .folder, let itemPath = item.fileURL?.path else { return false }
+        if _folderSelectionExclusions[item.id] != nil { return false }
+        guard item.sourceType == .folder,
+              let rawPath = item.fileURL?.path else { return false }
+        let normalizedPath = item.isFolder ? normalizedFolderPath(rawPath) : rawPath
+        if hasDeselectionOverride(forPath: normalizedPath, excluding: item.id) { return false }
         // Any selected folder that is an ancestor of this item implies effective selection
         for fid in selectedItemIds {
             if let folder = self.item(for: fid),
                folder.isFolder,
-               let folderPath = folder.fileURL?.path,
-               itemPath.hasPrefix(folderPath.hasSuffix("/") ? folderPath : folderPath + "/") {
-                // Ensure not the folder itself
-                if folder.id != item.id { return true }
+               let folderRawPath = folder.fileURL?.path {
+                let folderPath = normalizedFolderPath(folderRawPath)
+                if folder.id != item.id, normalizedPath.hasPrefix(folderPath) {
+                    return true
+                }
             }
         }
         return false
@@ -804,6 +920,7 @@ final class ContentManager {
                     let type = values.contentType ?? FileSystemSource.resolvedType(for: url)
                     let info = DescendantFileInfo(
                         id: stableUUID(for: url),
+                        path: url.path,
                         isText: isTextType(type)
                     )
                     results.append(info)
@@ -1110,6 +1227,7 @@ extension ContentManager {
         _decoratorCacheDirty.removeAll()
         _hiddenSelectedItems.removeAll()
         _pendingHiddenFetch.removeAll()
+        _folderSelectionExclusions.removeAll()
         removeDescendantEntries(withPrefix: nil)
     }
 }

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -137,6 +137,40 @@ final class ContentManager {
         _pendingHiddenFetch.formIntersection(selectedItemIds)
     }
 
+    func clearHiddenSelections(for sourceId: String, underPath prefixPath: String? = nil) {
+        guard !_hiddenSelectedItems.isEmpty else { return }
+
+        let normalizedPrefix: String? = {
+            guard let prefixPath else { return nil }
+            if prefixPath.hasSuffix("/") { return prefixPath }
+            return prefixPath + "/"
+        }()
+
+        var removedAny = false
+
+        for (id, item) in _hiddenSelectedItems where item.sourceId == sourceId {
+            if let prefixPath,
+               let itemPath = item.fileURL?.path {
+                if itemPath != prefixPath,
+                   let normalizedPrefix,
+                   !itemPath.hasPrefix(normalizedPrefix) {
+                    continue
+                }
+            } else if prefixPath != nil {
+                continue
+            }
+
+            _hiddenSelectedItems.removeValue(forKey: id)
+            _pendingHiddenFetch.remove(id)
+            removedAny = true
+        }
+
+        if removedAny {
+            markSelectedDirty()
+            _allItemsCacheDirty = true
+        }
+    }
+
     func item(for id: UUID?) -> ContentItem? {
         guard let id else { return nil }
         rebuildItemCachesIfNeeded()
@@ -484,13 +518,7 @@ final class ContentManager {
         }
 
         // Clear hidden caches tied to this source
-        let hiddenIdsToRemove = _hiddenSelectedItems
-            .filter { $0.value.sourceId == sourceId }
-            .map { $0.key }
-        for hiddenId in hiddenIdsToRemove {
-            _hiddenSelectedItems.removeValue(forKey: hiddenId)
-            _pendingHiddenFetch.remove(hiddenId)
-        }
+        clearHiddenSelections(for: sourceId)
 
         // For folder sources, also remove the bookmark
         if source.type == .folder {

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -552,30 +552,37 @@ final class ContentManager {
             return .partial
         }
         
-        // For expanded folders, calculate based on children selection (only count files, not subfolders)
+        // For expanded folders, calculate based on per-child state so mixed selections stay accurate
         let fileChildren = children.filter { !$0.isFolder }
-        let selectedFileChildren = fileChildren.filter { selectedItemIds.contains($0.id) }
-        
-        // Also need to check if any subfolders have selected descendants
         let subfolders = children.filter { $0.isFolder }
-        var hasSelectedInSubfolders = false
-        for subfolder in subfolders {
-            if getFolderSelectionState(subfolder.id) != .none {
-                hasSelectedInSubfolders = true
-                break
+
+        var anySelection = false
+        var allFullySelected = true
+
+        // Files are fully selected only when their UUID is tracked in the selection set
+        for file in fileChildren {
+            if selectedItemIds.contains(file.id) {
+                anySelection = true
+            } else {
+                allFullySelected = false
             }
         }
-        
-        let totalSelected = selectedFileChildren.count + (hasSelectedInSubfolders ? 1 : 0)
-        let totalItems = fileChildren.count + (subfolders.isEmpty ? 0 : 1)
-        
-        if totalSelected == 0 {
-            return .none
-        } else if totalSelected == totalItems && selectedFileChildren.count == fileChildren.count {
-            return .all
-        } else {
-            return .partial
+
+        // Subfolders inherit their own state; aggregate precisely instead of collapsing to a single flag
+        for subfolder in subfolders {
+            switch getFolderSelectionState(subfolder.id) {
+            case .all:
+                anySelection = true
+            case .partial:
+                anySelection = true
+                allFullySelected = false
+            case .none:
+                allFullySelected = false
+            }
         }
+
+        guard anySelection else { return .none }
+        return allFullySelected ? .all : .partial
     }
     
     func focus(_ id: UUID?) {

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -51,6 +51,10 @@ final class ContentManager {
     // Cache for UniversalItemDecorator instances to maintain consistency
     @ObservationIgnored private var _decoratorCache: [String: [UUID: UniversalItemDecorator]] = [:] // sourceId -> [itemId -> decorator]
     @ObservationIgnored private var _decoratorCacheDirty: Set<String> = [] // sourceIds that need cache refresh
+
+    // Cache for hidden selections fetched off the main thread
+    @ObservationIgnored private var _hiddenSelectedItems: [UUID: ContentItem] = [:]
+    @ObservationIgnored private var _pendingHiddenFetch: Set<UUID> = []
     
     // (Removed) Aggregated display version tracking; Aggregated now shows only pasteable items
     
@@ -116,6 +120,9 @@ final class ContentManager {
 
     func markItemsDirty() {
         _allItemsCacheDirty = true
+        // Drop hidden cache entries that are no longer relevant
+        _hiddenSelectedItems = _hiddenSelectedItems.filter { selectedItemIds.contains($0.key) }
+        _pendingHiddenFetch.formIntersection(selectedItemIds)
     }
 
     func item(for id: UUID?) -> ContentItem? {
@@ -267,6 +274,8 @@ final class ContentManager {
         if sources["clipboard"] is ClipboardSource {
             History.shared.items.forEach { $0.isSelected = false }
         }
+        _hiddenSelectedItems.removeAll()
+        _pendingHiddenFetch.removeAll()
         markSelectedDirty()
     }
     
@@ -437,7 +446,16 @@ final class ContentManager {
            sourceItems.contains(where: { $0.id == focusedId }) {
             focusedItemId = nil
         }
-        
+
+        // Clear hidden caches tied to this source
+        let hiddenIdsToRemove = _hiddenSelectedItems
+            .filter { $0.value.sourceId == sourceId }
+            .map { $0.key }
+        for hiddenId in hiddenIdsToRemove {
+            _hiddenSelectedItems.removeValue(forKey: hiddenId)
+            _pendingHiddenFetch.remove(hiddenId)
+        }
+
         // For folder sources, also remove the bookmark
         if source.type == .folder {
             // Prefer obtaining the exact URL from FileSystemSource
@@ -748,13 +766,15 @@ extension ContentManager {
         let hiddenSelectedIds = selectedItemIds.subtracting(visibleIds)
 
         if !hiddenSelectedIds.isEmpty {
-            // Check each source for selected items that might be hidden (files in collapsed folders)
-            for sourceId in orderedSourceIds {
-                guard let source = sources[sourceId] as? FileSystemSource else { continue }
+            let cachedHidden = hiddenSelectedIds.compactMap { _hiddenSelectedItems[$0] }
+            if !cachedHidden.isEmpty {
+                hiddenSelectedItems.append(contentsOf: cachedHidden.filter { !$0.isFolder })
+            }
 
-                // Scan the filesystem to find these hidden selected files
-                let foundItems = source.findItemsById(hiddenSelectedIds)
-                hiddenSelectedItems.append(contentsOf: foundItems.filter { !$0.isFolder })
+            let cachedIds = Set(cachedHidden.map { $0.id })
+            let missingHidden = hiddenSelectedIds.subtracting(cachedIds)
+            if !missingHidden.isEmpty {
+                scheduleHiddenSelectionPrefetch(for: missingHidden)
             }
         }
 
@@ -813,5 +833,52 @@ extension ContentManager {
         }
         
         return result
+    }
+}
+
+extension ContentManager {
+    private func scheduleHiddenSelectionPrefetch(for ids: Set<UUID>) {
+        let newRequests = ids.subtracting(_pendingHiddenFetch)
+        guard !newRequests.isEmpty else { return }
+
+        _pendingHiddenFetch.formUnion(newRequests)
+
+        Task.detached(priority: .utility) { [weak self] in
+            guard let self else { return }
+
+            var remaining = newRequests
+            let sources: [FileSystemSource] = await MainActor.run {
+                self.sources.values.compactMap { $0 as? FileSystemSource }
+            }
+
+            for source in sources {
+                guard !remaining.isEmpty else { break }
+                let found = await source.fetchItems(for: remaining)
+                guard !found.isEmpty else { continue }
+
+                let foundIds = Set(found.map { $0.id })
+                remaining.subtract(foundIds)
+
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    for item in found {
+                        self._hiddenSelectedItems[item.id] = item
+                    }
+                    self._pendingHiddenFetch.subtract(foundIds)
+
+                    // Only trigger a refresh if any of the resolved IDs are still selected
+                    if !foundIds.isDisjoint(with: self.selectedItemIds) {
+                        self.markSelectedDirty()
+                    }
+                }
+            }
+
+            if !remaining.isEmpty {
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    self._pendingHiddenFetch.subtract(remaining)
+                }
+            }
+        }
     }
 }

--- a/nozzle/Observables/FileSystemSource.swift
+++ b/nozzle/Observables/FileSystemSource.swift
@@ -183,6 +183,7 @@ final class FileSystemSource: ContentSource {
         ContentManager.shared.markItemsDirty()
         // Visible slice changed; invalidate selectedItems cache
         ContentManager.shared.markSelectedDirty()
+        ContentManager.shared.invalidateDescendantCache(under: folderURL.path)
 
 #if DEBUG
         let elapsed = Date().timeIntervalSince(refreshStart)
@@ -223,9 +224,11 @@ final class FileSystemSource: ContentSource {
             directoryModDateCache = directoryModDateCache.filter { cachedPath, _ in
                 !cachedPath.hasPrefix(specificPath)
             }
+            ContentManager.shared.invalidateDescendantCache(under: specificPath)
         } else {
             // Clear entire cache
             directoryModDateCache.removeAll()
+            ContentManager.shared.invalidateDescendantCache(under: folderURL.path)
         }
     }
 
@@ -272,6 +275,7 @@ final class FileSystemSource: ContentSource {
         // Visible slice changed; invalidate selectedItems cache and decorators cache
         ContentManager.shared.markDecoratorsNeedRefresh(for: self.id)
         ContentManager.shared.markSelectedDirty()
+        ContentManager.shared.invalidateDescendantCache(under: folderPath)
     }
 
     @MainActor

--- a/nozzle/Observables/FileSystemSource.swift
+++ b/nozzle/Observables/FileSystemSource.swift
@@ -286,7 +286,12 @@ final class FileSystemSource: ContentSource {
         return nil
     }
     
-    private func buildHierarchicalItems(at url: URL, depth: Int, parentPath: String?) async -> [ContentItem] {
+    private func buildHierarchicalItems(
+        at url: URL,
+        depth: Int,
+        parentPath: String?,
+        expandedPaths: Set<String>? = nil
+    ) async -> [ContentItem] {
         // Check if directory has changed before expensive scanning
         let hasChanged = await MainActor.run { self.hasDirectoryChanged(at: url) }
 
@@ -294,6 +299,13 @@ final class FileSystemSource: ContentSource {
         if !hasChanged && depth == 0 {
             // For root level, return existing cached items since directory is unchanged
             return await MainActor.run { self.cachedItems }
+        }
+
+        let expandedSet: Set<String>
+        if let expandedPaths {
+            expandedSet = expandedPaths
+        } else {
+            expandedSet = await MainActor.run { self.expansionState.getAllExpandedPaths() }
         }
 
         let (sortOrder, sortDirection) = await MainActor.run { (self.sortOrder, self.sortDirection) }
@@ -395,24 +407,18 @@ final class FileSystemSource: ContentSource {
             // If it's a folder and should be expanded, add its children
             if item.isFolder,
                let folderURL = item.fileURL,
-               depth < 3 { // Max depth limit
-                
-                // Check if this folder is expanded
-                let shouldExpand = await MainActor.run {
-                    return self.expansionState.isExpanded(folderURL.path)
-                }
-                
-                if shouldExpand {
-                    let childItems = await buildHierarchicalItems(
-                        at: folderURL,
-                        depth: depth + 1,
-                        parentPath: folderURL.path
-                    )
-                    allItems.append(contentsOf: childItems)
-                }
+               depth < 3,
+               expandedSet.contains(folderURL.path) {
+                let childItems = await buildHierarchicalItems(
+                    at: folderURL,
+                    depth: depth + 1,
+                    parentPath: folderURL.path,
+                    expandedPaths: expandedSet
+                )
+                allItems.append(contentsOf: childItems)
             }
         }
-        
+
         // Update directory modification date cache after successful scan
         await MainActor.run {
             self.updateDirectoryModDateCache(at: url)

--- a/nozzle/Observables/FileSystemSource.swift
+++ b/nozzle/Observables/FileSystemSource.swift
@@ -181,6 +181,7 @@ final class FileSystemSource: ContentSource {
         self.lastRefreshTime = Date()
         self.rebuildIndexes()
         ContentManager.shared.markItemsDirty()
+        ContentManager.shared.clearHiddenSelections(for: self.id, underPath: folderURL.path)
         // Visible slice changed; invalidate selectedItems cache
         ContentManager.shared.markSelectedDirty()
         ContentManager.shared.invalidateDescendantCache(under: folderURL.path)
@@ -225,10 +226,12 @@ final class FileSystemSource: ContentSource {
                 !cachedPath.hasPrefix(specificPath)
             }
             ContentManager.shared.invalidateDescendantCache(under: specificPath)
+            ContentManager.shared.clearHiddenSelections(for: id, underPath: specificPath)
         } else {
             // Clear entire cache
             directoryModDateCache.removeAll()
             ContentManager.shared.invalidateDescendantCache(under: folderURL.path)
+            ContentManager.shared.clearHiddenSelections(for: id, underPath: folderURL.path)
         }
     }
 
@@ -276,6 +279,7 @@ final class FileSystemSource: ContentSource {
         ContentManager.shared.markDecoratorsNeedRefresh(for: self.id)
         ContentManager.shared.markSelectedDirty()
         ContentManager.shared.invalidateDescendantCache(under: folderPath)
+        ContentManager.shared.clearHiddenSelections(for: self.id, underPath: folderPath)
     }
 
     @MainActor

--- a/nozzle/Observables/FileSystemSource.swift
+++ b/nozzle/Observables/FileSystemSource.swift
@@ -68,6 +68,12 @@ final class FileSystemSource: ContentSource {
     
     // Resort suspension for stable editing
     private var suspendResortItemId: UUID?
+
+    private struct DirectoryEntry {
+        let url: URL
+        let snapshot: FileIdentity.Snapshot
+        let typeIdentifier: String?
+    }
     
     init(folderURL: URL) {
         self.folderURL = folderURL
@@ -160,6 +166,7 @@ final class FileSystemSource: ContentSource {
         self.cachedItems = hierarchicalItems
         self.lastRefreshTime = Date()
         self.rebuildIndexes()
+        ContentManager.shared.markItemsDirty()
         // Visible slice changed; invalidate selectedItems cache
         ContentManager.shared.markSelectedDirty()
     }
@@ -242,6 +249,7 @@ final class FileSystemSource: ContentSource {
             cachedItems.replaceSubrange(start..<safeEnd, with: replacement)
         }
         rebuildIndexes()
+        ContentManager.shared.markItemsDirty()
         // Visible slice changed; invalidate selectedItems cache and decorators cache
         ContentManager.shared.markDecoratorsNeedRefresh(for: self.id)
         ContentManager.shared.markSelectedDirty()
@@ -262,106 +270,90 @@ final class FileSystemSource: ContentSource {
     private func buildHierarchicalItems(at url: URL, depth: Int, parentPath: String?) async -> [ContentItem] {
         // Check if directory has changed before expensive scanning
         let hasChanged = await MainActor.run { self.hasDirectoryChanged(at: url) }
-        
+
         // If directory hasn't changed and we have cached items for this path, return cached subset
         if !hasChanged && depth == 0 {
             // For root level, return existing cached items since directory is unchanged
             return await MainActor.run { self.cachedItems }
         }
-        
+
+        let (sortOrder, sortDirection) = await MainActor.run { (self.sortOrder, self.sortDirection) }
+        let sourceId = "folder:\(self.folderURL.path)"
+
         let task = Task.detached { () -> [ContentItem] in
             let fm = FileManager.default
-            // Only fetch isDirectory initially to separate folders/files
             guard let urls = try? fm.contentsOfDirectory(
                 at: url,
-                includingPropertiesForKeys: [.isDirectoryKey],
+                includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey, .fileSizeKey, .fileResourceIdentifierKey],
                 options: [.skipsHiddenFiles]
             ) else { return [] }
-            
-            var items: [ContentItem] = []
-            let sourceId = "folder:\(self.folderURL.path)"
-            
-            // Separate folders and files with minimal metadata
-            var folders: [(url: URL, isDir: Bool)] = []
-            var files: [(url: URL, isDir: Bool)] = []
-            
+
+            var folders: [DirectoryEntry] = []
+            var files: [DirectoryEntry] = []
+            folders.reserveCapacity(urls.count)
+            files.reserveCapacity(urls.count)
+
             for itemURL in urls {
-                // Skip excluded files/folders based on user patterns
                 if self.shouldExclude(filename: itemURL.lastPathComponent) {
                     continue
                 }
-                
-                let isDir = (try? itemURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
-                if isDir {
-                    folders.append((itemURL, isDir))
+
+                let snapshot = FileIdentity.snapshot(for: itemURL)
+                if snapshot.isDirectory {
+                    folders.append(DirectoryEntry(url: itemURL, snapshot: snapshot, typeIdentifier: nil))
                 } else {
-                    files.append((itemURL, isDir))
+                    let typeIdentifier = Self.resolvedType(for: itemURL)?.identifier
+                    files.append(DirectoryEntry(url: itemURL, snapshot: snapshot, typeIdentifier: typeIdentifier))
                 }
             }
-            
-            // Sort folders first, then files
-            let sortOrder = await MainActor.run { self.sortOrder }
-            let sortDirection = await MainActor.run { self.sortDirection }
-            
-            folders.sort { self.sortFiles($0.url, $1.url, order: sortOrder, direction: sortDirection) }
-            files.sort { self.sortFiles($0.url, $1.url, order: sortOrder, direction: sortDirection) }
-            
-            // Add folders
-            for (folderURL, _) in folders {
-                // Fetch metadata once per folder
-                let snap = FileIdentity.snapshot(for: folderURL)
-                // Derive a stable UUID from the file identity when available;
-                // fall back to absolute path for determinism (not mod date).
-                let uuid = Self.makeStableUUID(identity: snap.identity, fallbackPath: folderURL.absoluteString)
-                
+
+            folders.sort { Self.sortEntries($0, $1, order: sortOrder, direction: sortDirection) }
+            files.sort { Self.sortEntries($0, $1, order: sortOrder, direction: sortDirection) }
+
+            var items: [ContentItem] = []
+            items.reserveCapacity(folders.count + files.count)
+
+            for folder in folders {
+                let uuid = Self.makeStableUUID(identity: folder.snapshot.identity, fallbackPath: folder.url.absoluteString)
                 let folderItem = ContentItem(
                     id: uuid,
-                    title: folderURL.lastPathComponent,
-                    timestamp: snap.modDate,
+                    title: folder.url.lastPathComponent,
+                    timestamp: folder.snapshot.modDate,
                     sourceType: .folder,
                     sourceId: sourceId,
-                    fileURL: folderURL,
-                    plainText: folderURL.path,
-                    fileIdentity: snap.identity,
+                    fileURL: folder.url,
+                    plainText: folder.url.path,
+                    fileIdentity: folder.snapshot.identity,
                     isFolder: true,
                     depth: depth,
                     parentPath: parentPath
                 )
                 items.append(folderItem)
             }
-            
-            // Add files
-            for (fileURL, _) in files {
-                // Fetch metadata once per file
-                let snap = FileIdentity.snapshot(for: fileURL)
-                let type = Self.resolvedType(for: fileURL)
-                // File size is already fetched in snap
-                let fileSize = snap.size
-                
-                // Use stable identity-based UUID to prevent ID churn on save.
-                let uuid = Self.makeStableUUID(identity: snap.identity, fallbackPath: fileURL.absoluteString)
-                
+
+            for file in files {
+                let uuid = Self.makeStableUUID(identity: file.snapshot.identity, fallbackPath: file.url.absoluteString)
                 let fileItem = ContentItem(
                     id: uuid,
-                    title: fileURL.lastPathComponent,
-                    timestamp: snap.modDate,
+                    title: file.url.lastPathComponent,
+                    timestamp: file.snapshot.modDate,
                     sourceType: .folder,
                     sourceId: sourceId,
-                    fileURL: fileURL,
-                    plainText: fileURL.path,
-                    fileIdentity: snap.identity,
-                    uniformTypeIdentifier: type?.identifier,
-                    fileSize: fileSize,
+                    fileURL: file.url,
+                    plainText: file.url.path,
+                    fileIdentity: file.snapshot.identity,
+                    uniformTypeIdentifier: file.typeIdentifier,
+                    fileSize: file.snapshot.size,
                     isFolder: false,
                     depth: depth,
                     parentPath: parentPath
                 )
                 items.append(fileItem)
             }
-            
+
             return items
         }
-        
+
         let rootItems = await task.value
         var allItems: [ContentItem] = []
         
@@ -494,30 +486,28 @@ final class FileSystemSource: ContentSource {
         }
     }
     
-    private nonisolated func sortFiles(_ file1: URL, _ file2: URL, order: FileSortOrder, direction: FileSortDirection) -> Bool {
-        let result: Bool
-        
+    private nonisolated static func sortEntries(_ lhs: DirectoryEntry, _ rhs: DirectoryEntry, order: FileSortOrder, direction: FileSortDirection) -> Bool {
+        let ascending: Bool
+
         switch order {
         case .name:
-            result = file1.lastPathComponent.localizedCompare(file2.lastPathComponent) == .orderedAscending
-            
+            ascending = lhs.url.lastPathComponent.localizedCompare(rhs.url.lastPathComponent) == .orderedAscending
+
         case .dateModified:
-            let date1 = (try? file1.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? Date.distantPast
-            let date2 = (try? file2.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? Date.distantPast
-            result = date1 < date2
-            
+            ascending = lhs.snapshot.modDate < rhs.snapshot.modDate
+
         case .size:
-            let size1 = (try? file1.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
-            let size2 = (try? file2.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
-            result = size1 < size2
-            
+            let lhsSize = lhs.snapshot.size ?? 0
+            let rhsSize = rhs.snapshot.size ?? 0
+            ascending = lhsSize < rhsSize
+
         case .type:
-            let ext1 = file1.pathExtension.lowercased()
-            let ext2 = file2.pathExtension.lowercased()
-            result = ext1.localizedCompare(ext2) == .orderedAscending
+            let lhsType = lhs.typeIdentifier ?? lhs.url.pathExtension.lowercased()
+            let rhsType = rhs.typeIdentifier ?? rhs.url.pathExtension.lowercased()
+            ascending = lhsType.localizedCompare(rhsType) == .orderedAscending
         }
-        
-        return direction == .ascending ? result : !result
+
+        return direction == .ascending ? ascending : !ascending
     }
 }
 

--- a/nozzle/Observables/FileSystemSource.swift
+++ b/nozzle/Observables/FileSystemSource.swift
@@ -2,6 +2,7 @@ import AppKit
 import UniformTypeIdentifiers
 import Observation
 import CoreServices
+import OSLog
 import Defaults
 
 // MARK: - Sorting Enums
@@ -20,6 +21,15 @@ enum FileSortDirection: String, CaseIterable {
 
 @Observable @MainActor
 final class FileSystemSource: ContentSource {
+    private static let refreshLogger = Logger(subsystem: "org.conmeara.nozzle.content", category: "FileSystemSource")
+    private static let directoryResourceKeys: Set<URLResourceKey> = [
+        .isDirectoryKey,
+        .contentModificationDateKey,
+        .fileSizeKey,
+        .fileResourceIdentifierKey,
+        .contentTypeKey
+    ]
+
     nonisolated let id: String  // Need nonisolated access for event persistence
     let name: String
     let icon: NSImage
@@ -160,7 +170,11 @@ final class FileSystemSource: ContentSource {
     private func forceRefresh() async {
         // Mark decorators as needing refresh before updating items
         ContentManager.shared.markDecoratorsNeedRefresh(for: self.id)
-        
+
+#if DEBUG
+        let refreshStart = Date()
+#endif
+
         // Build hierarchical structure starting from root
         let hierarchicalItems = await buildHierarchicalItems(at: folderURL, depth: 0, parentPath: nil)
         self.cachedItems = hierarchicalItems
@@ -169,6 +183,11 @@ final class FileSystemSource: ContentSource {
         ContentManager.shared.markItemsDirty()
         // Visible slice changed; invalidate selectedItems cache
         ContentManager.shared.markSelectedDirty()
+
+#if DEBUG
+        let elapsed = Date().timeIntervalSince(refreshStart)
+        Self.refreshLogger.debug("forceRefresh(\(self.folderURL.lastPathComponent, privacy: .public)) duration=\(elapsed, privacy: .public)s items=\(hierarchicalItems.count, privacy: .public)")
+#endif
     }
     
     // Check if directory has been modified since last cache
@@ -280,11 +299,12 @@ final class FileSystemSource: ContentSource {
         let (sortOrder, sortDirection) = await MainActor.run { (self.sortOrder, self.sortDirection) }
         let sourceId = "folder:\(self.folderURL.path)"
 
+        let resourceKeys = Self.directoryResourceKeys
         let task = Task.detached { () -> [ContentItem] in
             let fm = FileManager.default
             guard let urls = try? fm.contentsOfDirectory(
                 at: url,
-                includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey, .fileSizeKey, .fileResourceIdentifierKey],
+                includingPropertiesForKeys: Array(resourceKeys),
                 options: [.skipsHiddenFiles]
             ) else { return [] }
 
@@ -298,11 +318,23 @@ final class FileSystemSource: ContentSource {
                     continue
                 }
 
-                let snapshot = FileIdentity.snapshot(for: itemURL)
+                guard let resourceValues = try? itemURL.resourceValues(forKeys: resourceKeys) else { continue }
+                let snapshot = FileIdentity.Snapshot(
+                    identity: resourceValues.fileResourceIdentifier as? Data,
+                    modDate: resourceValues.contentModificationDate ?? .distantPast,
+                    isDirectory: resourceValues.isDirectory ?? false,
+                    size: resourceValues.fileSize.map { Int64($0) }
+                )
+
                 if snapshot.isDirectory {
                     folders.append(DirectoryEntry(url: itemURL, snapshot: snapshot, typeIdentifier: nil))
                 } else {
-                    let typeIdentifier = Self.resolvedType(for: itemURL)?.identifier
+                    let typeIdentifier: String?
+                    if let type = resourceValues.contentType {
+                        typeIdentifier = type.identifier
+                    } else {
+                        typeIdentifier = Self.resolvedType(for: itemURL)?.identifier
+                    }
                     files.append(DirectoryEntry(url: itemURL, snapshot: snapshot, typeIdentifier: typeIdentifier))
                 }
             }
@@ -397,64 +429,59 @@ final class FileSystemSource: ContentSource {
     }
     
     // Find items by their IDs, even if they're not currently visible (collapsed folders)
-    func findItemsById(_ ids: Set<UUID>) -> [ContentItem] {
+    func fetchItems(for ids: Set<UUID>) async -> [ContentItem] {
         guard !ids.isEmpty else { return [] }
-        
-        var foundItems: [ContentItem] = []
-        let fm = FileManager.default
-        
-        // Recursively scan the folder to find matching items
-        if let enumerator = fm.enumerator(
-            at: folderURL,
-            includingPropertiesForKeys: [.isDirectoryKey, .contentTypeKey, .contentModificationDateKey, .fileSizeKey],
-            options: [.skipsHiddenFiles]
-        ) {
-            for case let url as URL in enumerator {
-                // Generate stable UUID for this URL
-                let itemId = Self.makeStableUUID(
-                    identity: FileIdentity.snapshot(for: url).identity,
-                    fallbackPath: url.absoluteString
+
+        let baseURL = folderURL
+        let sourceId = self.id
+        let resourceKeys = Self.directoryResourceKeys
+
+        return await Task.detached(priority: .utility) { () -> [ContentItem] in
+            var foundItems: [ContentItem] = []
+            let fm = FileManager.default
+
+            guard let enumerator = fm.enumerator(
+                at: baseURL,
+                includingPropertiesForKeys: Array(resourceKeys),
+                options: [.skipsHiddenFiles]
+            ) else { return [] }
+
+            while let url = enumerator.nextObject() as? URL {
+                guard let values = try? url.resourceValues(forKeys: resourceKeys) else { continue }
+                let identity = values.fileResourceIdentifier as? Data
+                let itemId = Self.makeStableUUID(identity: identity, fallbackPath: url.absoluteString)
+                guard ids.contains(itemId) else { continue }
+
+                let isDirectory = values.isDirectory == true
+                let timestamp = values.contentModificationDate ?? Date()
+                let uniformType = values.contentType?.identifier ?? (isDirectory ? nil : Self.resolvedType(for: url)?.identifier)
+                let relativePath = url.path.replacingOccurrences(of: baseURL.path + "/", with: "")
+                let depth = relativePath.components(separatedBy: "/").count
+                let parentPath = url.deletingLastPathComponent().path
+
+                let item = ContentItem(
+                    id: itemId,
+                    title: url.lastPathComponent,
+                    timestamp: timestamp,
+                    sourceType: .folder,
+                    sourceId: sourceId,
+                    fileURL: url,
+                    uniformTypeIdentifier: uniformType,
+                    fileSize: values.fileSize.map { Int64($0) },
+                    isFolder: isDirectory,
+                    depth: depth,
+                    parentPath: parentPath == baseURL.path ? nil : parentPath,
+                    isSelected: true
                 )
-                
-                // Check if this ID is one we're looking for
-                if ids.contains(itemId) {
-                    do {
-                        let vals = try url.resourceValues(forKeys: [.isDirectoryKey, .contentTypeKey, .contentModificationDateKey, .fileSizeKey])
-                        
-                        // Calculate depth and parent path
-                        let relativePath = url.path.replacingOccurrences(of: folderURL.path + "/", with: "")
-                        let depth = relativePath.components(separatedBy: "/").count
-                        let parentPath = url.deletingLastPathComponent().path
-                        
-                        let contentItem = ContentItem(
-                            id: itemId,
-                            title: url.lastPathComponent,
-                            timestamp: vals.contentModificationDate ?? Date(),
-                            sourceType: .folder,
-                            sourceId: self.id,
-                            fileURL: url,
-                            uniformTypeIdentifier: vals.contentType?.identifier,
-                            fileSize: Int64(vals.fileSize ?? 0),
-                            isFolder: vals.isDirectory == true,
-                            depth: depth,
-                            parentPath: parentPath == folderURL.path ? nil : parentPath,
-                            isSelected: true // These are selected items
-                        )
-                        
-                        foundItems.append(contentItem)
-                        
-                        // Stop early if we've found all items
-                        if foundItems.count == ids.count {
-                            break
-                        }
-                    } catch {
-                        continue
-                    }
+                foundItems.append(item)
+
+                if foundItems.count == ids.count {
+                    break
                 }
             }
-        }
-        
-        return foundItems
+
+            return foundItems
+        }.value
     }
     
     // MARK: - Folder expansion methods

--- a/nozzle/Observables/History.swift
+++ b/nozzle/Observables/History.swift
@@ -15,11 +15,7 @@ class History { // swiftlint:disable:this type_body_length
 
   var items: [HistoryItemDecorator] = [] {
     didSet {
-      // Visible list for clipboard changed; refresh selectedItems cache order
-      ContentManager.shared.markSelectedDirty()
-      ContentManager.shared.markItemsDirty()
-      ContentManager.shared.markDecoratorsNeedRefresh(for: "clipboard")
-      contentVersion &+= 1
+      notifyContentChanged()
     }
   }
   var selectedItem: HistoryItemDecorator? {
@@ -41,6 +37,10 @@ class History { // swiftlint:disable:this type_body_length
   var unpinnedItems: [HistoryItemDecorator] { items.filter(\.isUnpinned) }
 
   var itemsRevision: Int { contentVersion }
+
+  func registerDecoratorMutation() {
+    notifyContentChanged()
+  }
 
   var searchQuery: String = "" {
     didSet {
@@ -122,6 +122,7 @@ class History { // swiftlint:disable:this type_body_length
           item.title = title
           item.item.title = title
         }
+        notifyContentChanged()
       }
     }
 
@@ -413,5 +414,12 @@ class History { // swiftlint:disable:this type_body_length
       item.shortcuts = KeyShortcut.create(character: String(index))
       index += 1
     }
+  }
+
+  private func notifyContentChanged() {
+    ContentManager.shared.markSelectedDirty()
+    ContentManager.shared.markItemsDirty()
+    ContentManager.shared.markDecoratorsNeedRefresh(for: "clipboard")
+    contentVersion &+= 1
   }
 }

--- a/nozzle/Observables/History.swift
+++ b/nozzle/Observables/History.swift
@@ -18,6 +18,7 @@ class History { // swiftlint:disable:this type_body_length
       // Visible list for clipboard changed; refresh selectedItems cache order
       ContentManager.shared.markSelectedDirty()
       ContentManager.shared.markItemsDirty()
+      ContentManager.shared.markDecoratorsNeedRefresh(for: "clipboard")
       contentVersion &+= 1
     }
   }

--- a/nozzle/Observables/History.swift
+++ b/nozzle/Observables/History.swift
@@ -10,10 +10,15 @@ import SwiftData
 class History { // swiftlint:disable:this type_body_length
   static let shared = History()
 
+  @ObservationIgnored
+  private(set) var contentVersion: Int = 0
+
   var items: [HistoryItemDecorator] = [] {
     didSet {
       // Visible list for clipboard changed; refresh selectedItems cache order
       ContentManager.shared.markSelectedDirty()
+      ContentManager.shared.markItemsDirty()
+      contentVersion &+= 1
     }
   }
   var selectedItem: HistoryItemDecorator? {
@@ -33,6 +38,8 @@ class History { // swiftlint:disable:this type_body_length
 
   var pinnedItems: [HistoryItemDecorator] { items.filter(\.isPinned) }
   var unpinnedItems: [HistoryItemDecorator] { items.filter(\.isUnpinned) }
+
+  var itemsRevision: Int { contentVersion }
 
   var searchQuery: String = "" {
     didSet {

--- a/nozzle/Observables/HistoryItemDecorator.swift
+++ b/nozzle/Observables/HistoryItemDecorator.swift
@@ -23,11 +23,29 @@ class HistoryItemDecorator: ListItemDecorator {
 
   let id = UUID()
 
-  var title: String = ""
+  @ObservationIgnored
+  private var hasFinishedInitialization = false
+
+  var title: String = "" {
+    didSet {
+      guard hasFinishedInitialization, oldValue != title else { return }
+      History.shared.registerDecoratorMutation()
+    }
+  }
   var attributedTitle: AttributedString?
 
-  var isVisible: Bool = true
-  var isSelected: Bool = false
+  var isVisible: Bool = true {
+    didSet {
+      guard hasFinishedInitialization, oldValue != isVisible else { return }
+      History.shared.registerDecoratorMutation()
+    }
+  }
+  var isSelected: Bool = false {
+    didSet {
+      guard hasFinishedInitialization, oldValue != isSelected else { return }
+      History.shared.registerDecoratorMutation()
+    }
+  }
   // Note: We no longer tie isSelected to preview display
   // as isSelected now represents checkbox state, not focus state
   var shortcuts: [KeyShortcut] = []
@@ -157,6 +175,8 @@ class HistoryItemDecorator: ListItemDecorator {
     Task { @MainActor in
       sizeImages()
     }
+
+    hasFinishedInitialization = true
   }
 
   @MainActor

--- a/nozzle/Observables/UniversalItemDecorator.swift
+++ b/nozzle/Observables/UniversalItemDecorator.swift
@@ -14,6 +14,7 @@ final class UniversalItemDecorator: ListItemDecorator {
     
     // App icon for clipboard items
     private var _appIcon: ApplicationImage?
+    @ObservationIgnored private var isLoadingAppIcon: Bool = false
     
     // Static thumbnail size to match HistoryItemDecorator
     static var thumbnailImageSize: NSSize { 
@@ -52,26 +53,7 @@ final class UniversalItemDecorator: ListItemDecorator {
     // App icon for clipboard items
     var clipboardAppIcon: ApplicationImage? {
         if _appIcon == nil, base.sourceType == .clipboard {
-            // Derive effective bundle identifier, with heuristics for common sources like CleanShot
-            var effectiveBundleId = base.applicationBundleId
-            if let nozzleId = Bundle.main.bundleIdentifier, effectiveBundleId == nozzleId,
-               let url = base.fileURL, let guess = ScreenshotSourceHeuristics.guessBundleId(for: url) {
-                effectiveBundleId = guess
-            }
-            if effectiveBundleId == nil, let url = base.fileURL,
-               let guess = ScreenshotSourceHeuristics.guessBundleId(for: url) {
-                effectiveBundleId = guess
-            }
-
-            if let bundleId = effectiveBundleId {
-                Task {
-                    let appIcon = await ApplicationImageCache.shared.getImage(
-                        universalClipboard: false,
-                        application: bundleId
-                    )
-                    await MainActor.run { self._appIcon = appIcon }
-                }
-            }
+            prefetchAppIconIfNeeded()
         }
         return _appIcon
     }
@@ -117,18 +99,10 @@ final class UniversalItemDecorator: ListItemDecorator {
         self.base = item
         self.sourceId = item.sourceId
         self.isVisible = item.isVisible
-        
+
         // Initialize app icon for clipboard items
-        if item.sourceType == .clipboard, let bundleId = item.applicationBundleId {
-            Task {
-                let appIcon = await ApplicationImageCache.shared.getImage(
-                    universalClipboard: false, 
-                    application: bundleId
-                )
-                await MainActor.run {
-                    self._appIcon = appIcon
-                }
-            }
+        if item.sourceType == .clipboard {
+            prefetchAppIconIfNeeded()
         }
     }
     
@@ -145,23 +119,16 @@ final class UniversalItemDecorator: ListItemDecorator {
         // Clear cached app icon if the application changed
         if base.applicationBundleId != newItem.applicationBundleId {
             _appIcon = nil
+            isLoadingAppIcon = false
         }
-        
+
         // Update the base item
         base = newItem
         isVisible = newItem.isVisible
-        
+
         // Re-initialize app icon for clipboard items if needed
-        if newItem.sourceType == .clipboard, let bundleId = newItem.applicationBundleId, _appIcon == nil {
-            Task {
-                let appIcon = await ApplicationImageCache.shared.getImage(
-                    universalClipboard: false, 
-                    application: bundleId
-                )
-                await MainActor.run {
-                    self._appIcon = appIcon
-                }
-            }
+        if newItem.sourceType == .clipboard, _appIcon == nil {
+            prefetchAppIconIfNeeded()
         }
     }
     
@@ -198,5 +165,40 @@ final class UniversalItemDecorator: ListItemDecorator {
                 pasteboard.writeObjects([image])
             }
         }
+    }
+}
+
+private extension UniversalItemDecorator {
+    func prefetchAppIconIfNeeded() {
+        guard let bundleId = effectiveBundleIdentifier(for: base) else { return }
+        guard !isLoadingAppIcon else { return }
+        isLoadingAppIcon = true
+
+        Task(priority: .utility) { [weak self] in
+            let image = await ApplicationImageCache.shared.getImage(
+                universalClipboard: false,
+                application: bundleId
+            )
+            await MainActor.run {
+                guard let self else { return }
+                self._appIcon = image
+                self.isLoadingAppIcon = false
+            }
+        }
+    }
+
+    func effectiveBundleIdentifier(for item: ContentItem) -> String? {
+        var effectiveBundleId = item.applicationBundleId
+        if let nozzleId = Bundle.main.bundleIdentifier,
+           effectiveBundleId == nozzleId,
+           let url = item.fileURL,
+           let guess = ScreenshotSourceHeuristics.guessBundleId(for: url) {
+            effectiveBundleId = guess
+        }
+        if effectiveBundleId == nil, let url = item.fileURL,
+           let guess = ScreenshotSourceHeuristics.guessBundleId(for: url) {
+            effectiveBundleId = guess
+        }
+        return effectiveBundleId
     }
 }

--- a/nozzleTests/ContentManagerSelectionTests.swift
+++ b/nozzleTests/ContentManagerSelectionTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import nozzle
+
+@MainActor
+final class ContentManagerSelectionTests: XCTestCase {
+    func testHiddenSelectionPrefetchAddsFolderContext() async throws {
+        let manager = ContentManager.shared
+        manager.resetForTesting()
+
+        let tempRoot = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let nestedFolder = tempRoot.appendingPathComponent("Reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: nestedFolder, withIntermediateDirectories: true)
+        let hiddenFile = nestedFolder.appendingPathComponent("january.txt")
+        try "budget".write(to: hiddenFile, atomically: true, encoding: .utf8)
+
+        let source = FileSystemSource(folderURL: tempRoot)
+        manager.registerSource(source)
+        defer {
+            source.stopMonitoring()
+            manager.resetForTesting()
+        }
+
+        await source.refresh()
+
+        XCTAssertFalse(
+            source.items.contains(where: { $0.fileURL == hiddenFile }),
+            "Nested file should stay hidden while folder is collapsed"
+        )
+
+        let hiddenId = manager.stableUUID(for: hiddenFile)
+        manager.toggleSelection(hiddenId)
+
+        var resolvedItem: ContentItem?
+        let deadline = Date().addingTimeInterval(2.0)
+        repeat {
+            if let match = manager.selectedItems.first(where: { $0.id == hiddenId }) {
+                resolvedItem = match
+                break
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        } while Date() < deadline
+
+        XCTAssertNotNil(resolvedItem, "Hidden selection should surface after background fetch")
+        XCTAssertEqual(resolvedItem?.id, hiddenId)
+
+        let folderItem = try XCTUnwrap(manager.selectedItems.first(where: { $0.isFolder }))
+        XCTAssertEqual(folderItem.fileURL?.lastPathComponent, "Reports")
+
+        guard
+            let folderIndex = manager.selectedItems.firstIndex(where: { $0.id == folderItem.id }),
+            let fileIndex = manager.selectedItems.firstIndex(where: { $0.id == hiddenId })
+        else {
+            XCTFail("Expected both folder and file in aggregated selection")
+            return
+        }
+        XCTAssertLessThan(folderIndex, fileIndex)
+        XCTAssertEqual(manager.selectedItems[fileIndex].id, hiddenId)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "ContentManagerSelectionTests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/nozzleTests/ContentManagerSelectionTests.swift
+++ b/nozzleTests/ContentManagerSelectionTests.swift
@@ -57,6 +57,26 @@ final class ContentManagerSelectionTests: XCTestCase {
         }
         XCTAssertLessThan(folderIndex, fileIndex)
         XCTAssertEqual(manager.selectedItems[fileIndex].id, hiddenId)
+
+        // Rename the hidden file and ensure the cached selection refreshes
+        let renamedURL = nestedFolder.appendingPathComponent("february.txt")
+        try FileManager.default.moveItem(at: hiddenFile, to: renamedURL)
+
+        await source.refresh()
+
+        let renameDeadline = Date().addingTimeInterval(2.0)
+        var refreshedTitle: String?
+        repeat {
+            if let match = manager.selectedItems.first(where: { $0.id == hiddenId }) {
+                if match.title == "february.txt" {
+                    refreshedTitle = match.title
+                    break
+                }
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        } while Date() < renameDeadline
+
+        XCTAssertEqual(refreshedTitle, "february.txt", "Renamed hidden selection should refresh cached metadata")
     }
 
     private func makeTemporaryDirectory() throws -> URL {


### PR DESCRIPTION
## Summary
- integrate all optimize-performance-v2 improvements (caching, async refresh, selection batching)
- ensure collapsed and expanded folder selection states respect manual overrides and per-child accuracy
- keep decorators/tests in sync with unified multi-source architecture

## Testing
- xcodebuild -project nozzle.xcodeproj -scheme nozzle test -only-testing:nozzleTests/ContentManagerSelectionTests (fails: sandbox blocks Simulator/cache directories)
