### PR TITLE
Refine hierarchical selection orchestration

### DIFF
--- a/nozzle/Models/ContentSource.swift
+++ b/nozzle/Models/ContentSource.swift
@@ -18,15 +18,17 @@ public protocol ContentSource: AnyObject {
 }
 
 public struct HierarchyDescendantItem: Sendable {
-    public init(id: UUID, path: String, isText: Bool) {
+    public init(id: UUID, path: String, isText: Bool, isFolder: Bool) {
         self.id = id
         self.path = path
         self.isText = isText
+        self.isFolder = isFolder
     }
 
     public let id: UUID
     public let path: String
     public let isText: Bool
+    public let isFolder: Bool
 }
 
 public struct HierarchyDescendantSnapshot: Sendable {
@@ -41,7 +43,7 @@ public struct HierarchyDescendantSnapshot: Sendable {
     public var itemIds: [UUID] { items.map(\.id) }
 
     public var textItemIds: [UUID] {
-        items.filter(\.isText).map(\.id)
+        items.filter { $0.isText && !$0.isFolder }.map(\.id)
     }
 }
 

--- a/nozzle/Models/ContentSource.swift
+++ b/nozzle/Models/ContentSource.swift
@@ -16,3 +16,46 @@ public protocol ContentSource: AnyObject {
     func refresh() async
     func search(query: String) -> [ContentItem]
 }
+
+public struct HierarchyDescendantItem: Sendable {
+    public init(id: UUID, path: String, isText: Bool) {
+        self.id = id
+        self.path = path
+        self.isText = isText
+    }
+
+    public let id: UUID
+    public let path: String
+    public let isText: Bool
+}
+
+public struct HierarchyDescendantSnapshot: Sendable {
+    public init(items: [HierarchyDescendantItem]) {
+        self.items = items
+    }
+
+    public let items: [HierarchyDescendantItem]
+
+    public var isEmpty: Bool { items.isEmpty }
+
+    public var itemIds: [UUID] { items.map(\.id) }
+
+    public var textItemIds: [UUID] {
+        items.filter(\.isText).map(\.id)
+    }
+}
+
+@MainActor
+public protocol HierarchicalContentSource: ContentSource {
+    func item(with id: UUID) -> ContentItem?
+    func visibleChildren(of folderId: UUID) -> [ContentItem]
+    func descendantSnapshot(for folderId: UUID) -> HierarchyDescendantSnapshot
+    func resolveItems(for ids: Set<UUID>) async -> [ContentItem]
+    func descendantTextItemIDs(for folderId: UUID) -> [UUID]
+}
+
+public extension HierarchicalContentSource {
+    func descendantTextItemIDs(for folderId: UUID) -> [UUID] {
+        descendantSnapshot(for: folderId).textItemIds
+    }
+}

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -116,28 +116,37 @@ final class ContentManager {
             return prefixPath + "/"
         }()
 
-        var removedAny = false
+        var keysToRemove: [UUID] = []
 
         for (id, item) in _hiddenSelectedItems where item.sourceId == sourceId {
-            if let prefixPath,
-               let itemPath = item.fileURL?.path {
-                if itemPath != prefixPath,
-                   let normalizedPrefix,
-                   !itemPath.hasPrefix(normalizedPrefix) {
-                    continue
+            let shouldRemove: Bool
+
+            if let prefixPath {
+                guard let itemPath = item.fileURL?.path else { continue }
+                if itemPath == prefixPath {
+                    shouldRemove = true
+                } else if let normalizedPrefix {
+                    shouldRemove = itemPath.hasPrefix(normalizedPrefix)
+                } else {
+                    shouldRemove = false
                 }
-            } else if prefixPath != nil {
-                continue
+            } else {
+                shouldRemove = true
             }
 
-            _hiddenSelectedItems.removeValue(forKey: id)
-            _pendingHiddenFetch.remove(id)
-            removedAny = true
+            if shouldRemove {
+                keysToRemove.append(id)
+            }
         }
 
-        if removedAny {
-            markSelectedDirty()
+        guard !keysToRemove.isEmpty else { return }
+
+        for id in keysToRemove {
+            _hiddenSelectedItems.removeValue(forKey: id)
+            _pendingHiddenFetch.remove(id)
         }
+
+        markSelectedDirty()
     }
 
     func item(for id: UUID?) -> ContentItem? {
@@ -335,8 +344,12 @@ final class ContentManager {
         var changed = false
 
         for (id, override) in _folderSelectionExclusions {
-            guard let item = item(for: id),
-                  let newPath = normalizedPath(for: item) else {
+            guard let item = item(for: id) else {
+                changed = true
+                continue
+            }
+
+            guard let newPath = normalizedPath(for: item) else {
                 changed = true
                 continue
             }
@@ -405,7 +418,7 @@ final class ContentManager {
             } else {
                 snapshot = await self.snapshotOnMain(for: folderId, sourceId: sourceId)
             }
-            let snapshotIds = snapshot.isEmpty ? Set<UUID>() : Set(snapshot.itemIds)
+            let snapshotIds = snapshot.isEmpty ? Set<UUID>() : Set(snapshot.items.filter { !$0.isFolder }.map(\.id))
             if !snapshotIds.isEmpty {
                 await self.markHiddenFetchPending(for: snapshotIds)
             }
@@ -439,7 +452,7 @@ final class ContentManager {
             } else {
                 snapshot = await self.snapshotOnMain(for: folderId, sourceId: sourceId)
             }
-            let snapshotIds = snapshot.isEmpty ? Set<UUID>() : Set(snapshot.itemIds)
+            let snapshotIds = snapshot.isEmpty ? Set<UUID>() : Set(snapshot.items.filter { !$0.isFolder }.map(\.id))
             if !snapshotIds.isEmpty {
                 await self.markHiddenFetchPending(for: snapshotIds)
             }
@@ -515,7 +528,6 @@ final class ContentManager {
                 guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .contentTypeKey, .fileResourceIdentifierKey]) else {
                     continue
                 }
-                if values.isDirectory == true { continue }
 
                 let type = values.contentType ?? FileSystemSource.resolvedType(for: url)
                 let identity = values.fileResourceIdentifier as? Data
@@ -571,6 +583,13 @@ final class ContentManager {
 
         if selecting {
             for item in processed {
+                if item.isFolder {
+                    selectedItemIds.remove(item.id)
+                    exampleItemIds.remove(item.id)
+                    _folderSelectionExclusions.removeValue(forKey: item.id)
+                    continue
+                }
+
                 selectedItemIds.insert(item.id)
                 exampleItemIds.remove(item.id)
                 _folderSelectionExclusions.removeValue(forKey: item.id)
@@ -578,13 +597,20 @@ final class ContentManager {
                     _hiddenSelectedItems[item.id] = resolved
                 }
             }
-            if !processed.isEmpty {
-                _pendingHiddenFetch.subtract(Set(processed.map(\.id)))
+            let fileIDs = processed.filter { !$0.isFolder }.map(\.id)
+            if !fileIDs.isEmpty {
+                _pendingHiddenFetch.subtract(Set(fileIDs))
             }
         } else {
             for item in processed {
                 selectedItemIds.remove(item.id)
                 exampleItemIds.remove(item.id)
+
+                if item.isFolder {
+                    _folderSelectionExclusions.removeValue(forKey: item.id)
+                    continue
+                }
+
                 _hiddenSelectedItems.removeValue(forKey: item.id)
                 _pendingHiddenFetch.remove(item.id)
             }

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -377,6 +377,10 @@ final class ContentManager {
             } else {
                 snapshot = await self.snapshotOnMain(for: folderId, sourceId: sourceId)
             }
+            let snapshotIds = snapshot.isEmpty ? Set<UUID>() : Set(snapshot.itemIds)
+            if !snapshotIds.isEmpty {
+                await self.markHiddenFetchPending(for: snapshotIds)
+            }
             let resolvedItems: [ContentItem]
             if snapshot.isEmpty {
                 resolvedItems = []
@@ -406,6 +410,10 @@ final class ContentManager {
                 snapshot = ContentManager.makeDescendantSnapshot(atPath: folderPath)
             } else {
                 snapshot = await self.snapshotOnMain(for: folderId, sourceId: sourceId)
+            }
+            let snapshotIds = snapshot.isEmpty ? Set<UUID>() : Set(snapshot.itemIds)
+            if !snapshotIds.isEmpty {
+                await self.markHiddenFetchPending(for: snapshotIds)
             }
             let resolvedItems: [ContentItem]
             if snapshot.isEmpty {
@@ -457,6 +465,12 @@ final class ContentManager {
             return HierarchyDescendantSnapshot(items: [])
         }
         return source.descendantSnapshot(for: folderId)
+    }
+
+    @MainActor
+    private func markHiddenFetchPending(for ids: Set<UUID>) {
+        guard !ids.isEmpty else { return }
+        _pendingHiddenFetch.formUnion(ids)
     }
 
     nonisolated private static func makeDescendantSnapshot(atPath path: String) -> HierarchyDescendantSnapshot {

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -525,7 +525,8 @@ final class ContentManager {
                     HierarchyDescendantItem(
                         id: id,
                         path: url.path,
-                        isText: isTextType(type)
+                        isText: isTextType(type),
+                        isFolder: values.isDirectory == true
                     )
                 )
             }

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import UniformTypeIdentifiers
 import Observation
 
 enum FolderSelectionState {
@@ -368,7 +369,14 @@ final class ContentManager {
         let token = registerDescendantSelectionTask(for: folderId)
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self else { return }
-            let snapshot = await self.snapshotForFolder(folderId, sourceId: sourceId)
+            let context = await self.backgroundSelectionInputs(for: folderId, sourceId: sourceId)
+            let snapshot: HierarchyDescendantSnapshot
+            if let folderPath = context.folderPath,
+               context.supportsBackgroundEnumeration {
+                snapshot = ContentManager.makeDescendantSnapshot(atPath: folderPath)
+            } else {
+                snapshot = await self.snapshotOnMain(for: folderId, sourceId: sourceId)
+            }
             let resolvedItems: [ContentItem]
             if snapshot.isEmpty {
                 resolvedItems = []
@@ -391,7 +399,14 @@ final class ContentManager {
         let token = registerDescendantSelectionTask(for: folderId)
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self else { return }
-            let snapshot = await self.snapshotForFolder(folderId, sourceId: sourceId)
+            let context = await self.backgroundSelectionInputs(for: folderId, sourceId: sourceId)
+            let snapshot: HierarchyDescendantSnapshot
+            if let folderPath = context.folderPath,
+               context.supportsBackgroundEnumeration {
+                snapshot = ContentManager.makeDescendantSnapshot(atPath: folderPath)
+            } else {
+                snapshot = await self.snapshotOnMain(for: folderId, sourceId: sourceId)
+            }
             let resolvedItems: [ContentItem]
             if snapshot.isEmpty {
                 resolvedItems = []
@@ -415,12 +430,66 @@ final class ContentManager {
         return token
     }
 
+    private struct BackgroundSelectionContext: Sendable {
+        let folderPath: String?
+        let supportsBackgroundEnumeration: Bool
+    }
+
     @MainActor
-    private func snapshotForFolder(_ folderId: UUID, sourceId: String) -> HierarchyDescendantSnapshot {
+    private func backgroundSelectionInputs(for folderId: UUID, sourceId: String) -> BackgroundSelectionContext {
+        guard let source = sources[sourceId] else {
+            return BackgroundSelectionContext(folderPath: nil, supportsBackgroundEnumeration: false)
+        }
+
+        let item = source.items.first(where: { $0.id == folderId })
+        let folderPath = item?.fileURL?.path
+        let supportsBackground = source.type == .folder && folderPath != nil
+
+        return BackgroundSelectionContext(
+            folderPath: folderPath,
+            supportsBackgroundEnumeration: supportsBackground
+        )
+    }
+
+    @MainActor
+    private func snapshotOnMain(for folderId: UUID, sourceId: String) -> HierarchyDescendantSnapshot {
         guard let source = sources[sourceId] as? HierarchicalContentSource else {
             return HierarchyDescendantSnapshot(items: [])
         }
         return source.descendantSnapshot(for: folderId)
+    }
+
+    nonisolated private static func makeDescendantSnapshot(atPath path: String) -> HierarchyDescendantSnapshot {
+        let baseURL = URL(fileURLWithPath: path)
+        var descendants: [HierarchyDescendantItem] = []
+        let fm = FileManager.default
+
+        if let enumerator = fm.enumerator(
+            at: baseURL,
+            includingPropertiesForKeys: [.isDirectoryKey, .contentTypeKey, .fileResourceIdentifierKey],
+            options: [.skipsHiddenFiles]
+        ) {
+            for case let url as URL in enumerator {
+                guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .contentTypeKey, .fileResourceIdentifierKey]) else {
+                    continue
+                }
+                if values.isDirectory == true { continue }
+
+                let type = values.contentType ?? FileSystemSource.resolvedType(for: url)
+                let identity = values.fileResourceIdentifier as? Data
+                let id = FileSystemSource.makeStableUUID(identity: identity, fallbackPath: url.absoluteString)
+
+                descendants.append(
+                    HierarchyDescendantItem(
+                        id: id,
+                        path: url.path,
+                        isText: isTextType(type)
+                    )
+                )
+            }
+        }
+
+        return HierarchyDescendantSnapshot(items: descendants)
     }
 
     @MainActor
@@ -1089,6 +1158,20 @@ extension ContentManager {
                 }
             }
         }
+    }
+}
+
+private extension ContentManager {
+    nonisolated static func isTextType(_ type: UTType?) -> Bool {
+        guard let type else { return false }
+        if type.conforms(to: .text) { return true }
+        if type == .rtf || type == .rtfd || type == .html { return true }
+        if type.identifier == "net.daringfireball.markdown" ||
+            type.identifier == "public.markdown" ||
+            type.preferredFilenameExtension == "md" {
+            return true
+        }
+        return false
     }
 }
 

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -104,6 +104,7 @@ final class ContentManager {
     func markItemsDirty() {
         _hiddenSelectedItems = _hiddenSelectedItems.filter { selectedItemIds.contains($0.key) }
         _pendingHiddenFetch.formIntersection(selectedItemIds)
+        resyncDeselectionOverridesWithCurrentPaths()
     }
 
     func clearHiddenSelections(for sourceId: String, underPath prefixPath: String? = nil) {
@@ -324,6 +325,33 @@ final class ContentManager {
               let path = normalizedPath(for: item) else { return false }
         if _folderSelectionExclusions[item.id] != nil { return true }
         return hasDeselectionOverride(forPath: path, excluding: item.id)
+    }
+
+    private func resyncDeselectionOverridesWithCurrentPaths() {
+        guard !_folderSelectionExclusions.isEmpty else { return }
+
+        var updated: [UUID: DeselectionOverride] = [:]
+        updated.reserveCapacity(_folderSelectionExclusions.count)
+        var changed = false
+
+        for (id, override) in _folderSelectionExclusions {
+            guard let item = item(for: id),
+                  let newPath = normalizedPath(for: item) else {
+                changed = true
+                continue
+            }
+
+            if newPath != override.path {
+                updated[id] = DeselectionOverride(path: newPath, appliesToDescendants: override.appliesToDescendants)
+                changed = true
+            } else {
+                updated[id] = override
+            }
+        }
+
+        if changed {
+            _folderSelectionExclusions = updated
+        }
     }
 
     private func hasDeselectionOverride(forPath path: String, excluding id: UUID? = nil) -> Bool {

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -1,5 +1,5 @@
 import AppKit
-import UniformTypeIdentifiers
+import Foundation
 import Observation
 
 enum FolderSelectionState {
@@ -38,12 +38,6 @@ final class ContentManager {
     var isPromptEditorEditing: Bool = false
     var enhanceButtonClicked: Bool = false // Flag to prevent editor exit on enhance
     
-    // Cache for flattened content items to avoid repeated traversals
-    @ObservationIgnored private var _allItemsCache: [ContentItem] = []
-    @ObservationIgnored private var _allItemsCacheDirty: Bool = true
-    @ObservationIgnored private var _itemsById: [UUID: ContentItem] = [:]
-    @ObservationIgnored private var _itemsBySource: [String: [ContentItem]] = [:]
-
     // Cache for selected items to avoid repeated full scans and sorts
     @ObservationIgnored private var _selectedCache: [ContentItem] = []
     @ObservationIgnored private var _selectedCacheDirty: Bool = true
@@ -51,7 +45,22 @@ final class ContentManager {
     // Cache for UniversalItemDecorator instances to maintain consistency
     @ObservationIgnored private var _decoratorCache: [String: [UUID: UniversalItemDecorator]] = [:] // sourceId -> [itemId -> decorator]
     @ObservationIgnored private var _decoratorCacheDirty: Set<String> = [] // sourceIds that need cache refresh
-    
+
+    // Manual deselection tracking for folder descendants
+    @ObservationIgnored private var _folderSelectionExclusions: [UUID: DeselectionOverride] = [:]
+
+    // Cache for hidden selections fetched off the main thread
+    @ObservationIgnored private var _hiddenSelectedItems: [UUID: ContentItem] = [:]
+    @ObservationIgnored private var _pendingHiddenFetch: Set<UUID> = []
+
+    // Track in-flight descendant selection tasks per folder to avoid stale updates
+    @ObservationIgnored private var _descendantSelectionTokens: [UUID: UUID] = [:]
+
+    private struct DeselectionOverride: Sendable {
+        let path: String
+        let appliesToDescendants: Bool
+    }
+
     // (Removed) Aggregated display version tracking; Aggregated now shows only pasteable items
     
     var selectedItems: [ContentItem] {
@@ -82,8 +91,7 @@ final class ContentManager {
     }
     
     var allItems: [ContentItem] {
-        rebuildItemCachesIfNeeded()
-        return _allItemsCache
+        orderedSourceIds.flatMap { sources[$0]?.items ?? [] }
     }
     
     // Computed views
@@ -92,36 +100,62 @@ final class ContentManager {
         return src.items
     }
 
-    private func rebuildItemCachesIfNeeded() {
-        if !_allItemsCacheDirty { return }
-
-        var flattened: [ContentItem] = []
-        var byId: [UUID: ContentItem] = [:]
-        var bySource: [String: [ContentItem]] = [:]
-
-        for sourceId in orderedSourceIds {
-            guard let items = sources[sourceId]?.items else { continue }
-            flattened.append(contentsOf: items)
-            bySource[sourceId] = items
-            for item in items where byId[item.id] == nil {
-                byId[item.id] = item
-            }
-        }
-
-        _allItemsCache = flattened
-        _itemsById = byId
-        _itemsBySource = bySource
-        _allItemsCacheDirty = false
+    func markItemsDirty() {
+        _hiddenSelectedItems = _hiddenSelectedItems.filter { selectedItemIds.contains($0.key) }
+        _pendingHiddenFetch.formIntersection(selectedItemIds)
     }
 
-    func markItemsDirty() {
-        _allItemsCacheDirty = true
+    func clearHiddenSelections(for sourceId: String, underPath prefixPath: String? = nil) {
+        guard !_hiddenSelectedItems.isEmpty else { return }
+
+        let normalizedPrefix: String? = {
+            guard let prefixPath else { return nil }
+            if prefixPath.hasSuffix("/") { return prefixPath }
+            return prefixPath + "/"
+        }()
+
+        var removedAny = false
+
+        for (id, item) in _hiddenSelectedItems where item.sourceId == sourceId {
+            if let prefixPath,
+               let itemPath = item.fileURL?.path {
+                if itemPath != prefixPath,
+                   let normalizedPrefix,
+                   !itemPath.hasPrefix(normalizedPrefix) {
+                    continue
+                }
+            } else if prefixPath != nil {
+                continue
+            }
+
+            _hiddenSelectedItems.removeValue(forKey: id)
+            _pendingHiddenFetch.remove(id)
+            removedAny = true
+        }
+
+        if removedAny {
+            markSelectedDirty()
+        }
     }
 
     func item(for id: UUID?) -> ContentItem? {
         guard let id else { return nil }
-        rebuildItemCachesIfNeeded()
-        return _itemsById[id]
+        if let hidden = _hiddenSelectedItems[id] {
+            return hidden
+        }
+
+        for sourceId in orderedSourceIds {
+            guard let source = sources[sourceId] else { continue }
+            if let hierarchical = source as? HierarchicalContentSource,
+               let resolved = hierarchical.item(with: id) {
+                return resolved
+            }
+            if let match = source.items.first(where: { $0.id == id }) {
+                return match
+            }
+        }
+
+        return nil
     }
     
     // Selection management
@@ -139,6 +173,9 @@ final class ContentManager {
             } else {
                 selectedItemIds.insert(id)
             }
+            if let toggledItem = item(for: id) {
+                updateFolderDeselectionOverride(for: toggledItem, deselected: wasSelected)
+            }
             // Bridge to clipboard selection if needed
             syncClipboardSelection(id)
         }
@@ -147,19 +184,22 @@ final class ContentManager {
     
     private func toggleFolderSelection(_ folderId: UUID) {
         guard let folderItem = item(for: folderId),
-             folderItem.isFolder,
-             let folderPath = folderItem.fileURL?.path,
-             let folderURL = folderItem.fileURL else { return }
+              folderItem.isFolder,
+              sources[folderItem.sourceId] is HierarchicalContentSource else { return }
 
-        let children = allItems.filter { $0.parentPath == folderPath }
+        let children = visibleChildItems(of: folderItem)
         let currentState = getFolderSelectionState(folderId)
         
         switch currentState {
         case .none:
             // No children selected - select everything
+            removeDeselectionOverrides(inSubtreeOf: folderItem)
+            selectedItemIds.insert(folderId)
+            exampleItemIds.remove(folderId)
+            updateFolderDeselectionOverride(for: folderItem, deselected: false)
             if children.isEmpty {
-                // Collapsed folder - enumerate and select all descendant files
-                selectAllDescendantFiles(in: folderURL)
+                // Collapsed folder - enumerate and select all descendant files via source
+                selectAllDescendantItems(for: folderItem, sourceId: folderItem.sourceId)
             } else {
                 // Expanded folder - select all visible children
                 selectFolderChildren(folderId)
@@ -167,9 +207,12 @@ final class ContentManager {
             
         case .partial, .all:
             // Some or all children selected - deselect everything
+            selectedItemIds.remove(folderId)
+            exampleItemIds.remove(folderId)
+            updateFolderDeselectionOverride(for: folderItem, deselected: true)
             if children.isEmpty {
-                // Collapsed folder - enumerate and deselect all descendant files
-                deselectAllDescendantFiles(in: folderURL)
+                // Collapsed folder - enumerate and deselect all descendant files via source
+                deselectAllDescendantItems(for: folderItem, sourceId: folderItem.sourceId)
             } else {
                 // Expanded folder - deselect all visible children
                 deselectFolderChildren(folderId)
@@ -180,23 +223,28 @@ final class ContentManager {
     
     func selectFolderChildren(_ folderId: UUID) {
         guard let folderItem = item(for: folderId),
-             folderItem.isFolder,
-             let folderPath = folderItem.fileURL?.path else { return }
+              folderItem.isFolder,
+              sources[folderItem.sourceId] is HierarchicalContentSource else { return }
         
-        guard let sourceItems = _itemsBySource[folderItem.sourceId] else { return }
+        let children = visibleChildItems(of: folderItem)
 
-        // Select all visible children of this folder (but not the folder itself)
-        for item in sourceItems {
-            if item.parentPath == folderPath {
-                if item.isFolder {
-                    // Recursively select nested folder children
-                    selectFolderChildren(item.id)
-                } else {
-                    // Only add file IDs to selectedItemIds, not folder IDs
-                    selectedItemIds.insert(item.id)
-                    // Children are selected as context by default (not examples)
-                    exampleItemIds.remove(item.id)
-                }
+        selectedItemIds.insert(folderId)
+        exampleItemIds.remove(folderId)
+        updateFolderDeselectionOverride(for: folderItem, deselected: false)
+
+        if children.isEmpty {
+            selectAllDescendantItems(for: folderItem, sourceId: folderItem.sourceId)
+            return
+        }
+
+        for item in children {
+            guard !isUnderDeselectionOverride(item) else { continue }
+            if item.isFolder {
+                selectFolderChildren(item.id)
+            } else {
+                selectedItemIds.insert(item.id)
+                exampleItemIds.remove(item.id)
+                updateFolderDeselectionOverride(for: item, deselected: false)
             }
         }
         markSelectedDirty()
@@ -204,62 +252,234 @@ final class ContentManager {
     
     func deselectFolderChildren(_ folderId: UUID) {
         guard let folderItem = item(for: folderId),
-             folderItem.isFolder,
-             let folderPath = folderItem.fileURL?.path else { return }
-        
-        guard let sourceItems = _itemsBySource[folderItem.sourceId] else { return }
+              folderItem.isFolder,
+              sources[folderItem.sourceId] is HierarchicalContentSource else { return }
+
+        let children = visibleChildItems(of: folderItem)
+
+        selectedItemIds.remove(folderId)
+        exampleItemIds.remove(folderId)
+        updateFolderDeselectionOverride(for: folderItem, deselected: true)
+
+        if children.isEmpty {
+            deselectAllDescendantItems(for: folderItem, sourceId: folderItem.sourceId)
+            return
+        }
 
         // Deselect all children of this folder (but not the folder itself)
-        for item in sourceItems {
-            if item.parentPath == folderPath {
-                if item.isFolder {
-                    // Recursively deselect nested folder children
-                    deselectFolderChildren(item.id)
-                } else {
-                    // Only remove file IDs from selectedItemIds, not folder IDs
-                    selectedItemIds.remove(item.id)
-                    // Remove example flag when deselecting children
-                    exampleItemIds.remove(item.id)
-                }
+        for item in children {
+            if item.isFolder {
+                deselectFolderChildren(item.id)
+            } else {
+                selectedItemIds.remove(item.id)
+                exampleItemIds.remove(item.id)
+                updateFolderDeselectionOverride(for: item, deselected: true)
             }
         }
         markSelectedDirty()
+    }
+
+    private func updateFolderDeselectionOverride(for item: ContentItem, deselected: Bool) {
+        guard item.sourceType == .folder else {
+            _folderSelectionExclusions.removeValue(forKey: item.id)
+            return
+        }
+        guard let normalized = normalizedPath(for: item) else {
+            _folderSelectionExclusions.removeValue(forKey: item.id)
+            return
+        }
+
+        if deselected {
+            if hasSelectedFolderAncestor(for: item) {
+                _folderSelectionExclusions[item.id] = DeselectionOverride(
+                    path: normalized,
+                    appliesToDescendants: item.isFolder
+                )
+            } else {
+                _folderSelectionExclusions.removeValue(forKey: item.id)
+            }
+        } else {
+            _folderSelectionExclusions.removeValue(forKey: item.id)
+        }
+    }
+
+    private func removeDeselectionOverrides(inSubtreeOf folder: ContentItem) {
+        guard folder.sourceType == .folder,
+              let basePath = normalizedPath(for: folder),
+              !_folderSelectionExclusions.isEmpty else { return }
+
+        var toRemove: [UUID] = []
+        for (id, override) in _folderSelectionExclusions where override.path.hasPrefix(basePath) {
+            toRemove.append(id)
+        }
+
+        for id in toRemove {
+            _folderSelectionExclusions.removeValue(forKey: id)
+        }
+    }
+
+    private func isUnderDeselectionOverride(_ item: ContentItem) -> Bool {
+        guard item.sourceType == .folder,
+              let path = normalizedPath(for: item) else { return false }
+        if _folderSelectionExclusions[item.id] != nil { return true }
+        return hasDeselectionOverride(forPath: path, excluding: item.id)
+    }
+
+    private func hasDeselectionOverride(forPath path: String, excluding id: UUID? = nil) -> Bool {
+        guard !_folderSelectionExclusions.isEmpty else { return false }
+        for (key, override) in _folderSelectionExclusions {
+            if let id, key == id { continue }
+            if override.appliesToDescendants {
+                if path.hasPrefix(override.path) { return true }
+            } else if path == override.path {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func hasSelectedFolderAncestor(for item: ContentItem) -> Bool {
+        guard item.sourceType == .folder,
+              let itemPath = normalizedPath(for: item) else { return false }
+        for fid in selectedItemIds where fid != item.id {
+            guard let ancestor = self.item(for: fid),
+                  ancestor.isFolder,
+                  ancestor.sourceType == .folder,
+                  let ancestorPath = normalizedPath(for: ancestor) else { continue }
+            if itemPath.hasPrefix(ancestorPath) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func normalizedPath(for item: ContentItem) -> String? {
+        guard let path = item.fileURL?.path else { return nil }
+        return item.isFolder ? normalizedFolderPath(path) : path
+    }
+
+    private func normalizedFolderPath(_ path: String) -> String {
+        path.hasSuffix("/") ? path : path + "/"
     }
     
     // Helper functions for collapsed folder selection
-    private func selectAllDescendantFiles(in folderURL: URL) {
+    private func selectAllDescendantItems(for folder: ContentItem, sourceId: String) {
+        let folderId = folder.id
+        let token = registerDescendantSelectionTask(for: folderId)
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self else { return }
-            let descendantURLs = self.enumerateDescendantFiles(at: folderURL)
-            await self.applyDescendantSelection(urls: descendantURLs, selecting: true)
+            let snapshot = await self.snapshotForFolder(folderId, sourceId: sourceId)
+            let resolvedItems: [ContentItem]
+            if snapshot.isEmpty {
+                resolvedItems = []
+            } else {
+                let ids = Set(snapshot.itemIds)
+                resolvedItems = await self.resolveItemsOnMain(for: ids, sourceId: sourceId)
+            }
+            await self.applyDescendantSelection(
+                snapshot: snapshot,
+                resolvedItems: resolvedItems,
+                selecting: true,
+                folderId: folderId,
+                token: token
+            )
         }
     }
-    
-    private func deselectAllDescendantFiles(in folderURL: URL) {
+
+    private func deselectAllDescendantItems(for folder: ContentItem, sourceId: String) {
+        let folderId = folder.id
+        let token = registerDescendantSelectionTask(for: folderId)
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self else { return }
-            let descendantURLs = self.enumerateDescendantFiles(at: folderURL)
-            await self.applyDescendantSelection(urls: descendantURLs, selecting: false)
+            let snapshot = await self.snapshotForFolder(folderId, sourceId: sourceId)
+            let resolvedItems: [ContentItem]
+            if snapshot.isEmpty {
+                resolvedItems = []
+            } else {
+                let ids = Set(snapshot.itemIds)
+                resolvedItems = await self.resolveItemsOnMain(for: ids, sourceId: sourceId)
+            }
+            await self.applyDescendantSelection(
+                snapshot: snapshot,
+                resolvedItems: resolvedItems,
+                selecting: false,
+                folderId: folderId,
+                token: token
+            )
         }
+    }
+
+    private func registerDescendantSelectionTask(for folderId: UUID) -> UUID {
+        let token = UUID()
+        _descendantSelectionTokens[folderId] = token
+        return token
     }
 
     @MainActor
-    private func applyDescendantSelection(urls: [URL], selecting: Bool) {
-        guard !urls.isEmpty else { return }
+    private func snapshotForFolder(_ folderId: UUID, sourceId: String) -> HierarchyDescendantSnapshot {
+        guard let source = sources[sourceId] as? HierarchicalContentSource else {
+            return HierarchyDescendantSnapshot(items: [])
+        }
+        return source.descendantSnapshot(for: folderId)
+    }
 
-        for url in urls {
-            let fileId = stableUUID(for: url)
-            if selecting {
-                selectedItemIds.insert(fileId)
-                exampleItemIds.remove(fileId)
-            } else {
-                selectedItemIds.remove(fileId)
-                exampleItemIds.remove(fileId)
+    @MainActor
+    private func resolveItemsOnMain(for ids: Set<UUID>, sourceId: String) async -> [ContentItem] {
+        guard let source = sources[sourceId] as? HierarchicalContentSource else { return [] }
+        return await source.resolveItems(for: ids)
+    }
+
+    @MainActor
+    private func applyDescendantSelection(
+        snapshot: HierarchyDescendantSnapshot,
+        resolvedItems: [ContentItem],
+        selecting: Bool,
+        folderId: UUID,
+        token: UUID
+    ) {
+        guard _descendantSelectionTokens[folderId] == token else { return }
+        _descendantSelectionTokens.removeValue(forKey: folderId)
+
+        guard !snapshot.isEmpty else { return }
+
+        if selecting {
+            guard selectedItemIds.contains(folderId) else { return }
+        } else {
+            guard !selectedItemIds.contains(folderId) else { return }
+        }
+
+        let resolvedById = Dictionary(uniqueKeysWithValues: resolvedItems.map { ($0.id, $0) })
+
+        let processed: [HierarchyDescendantItem]
+        if selecting {
+            processed = snapshot.items.filter { !hasDeselectionOverride(forPath: $0.path) }
+        } else {
+            processed = snapshot.items
+        }
+
+        if selecting {
+            for item in processed {
+                selectedItemIds.insert(item.id)
+                exampleItemIds.remove(item.id)
+                _folderSelectionExclusions.removeValue(forKey: item.id)
+                if let resolved = resolvedById[item.id] {
+                    _hiddenSelectedItems[item.id] = resolved
+                }
+            }
+            if !processed.isEmpty {
+                _pendingHiddenFetch.subtract(Set(processed.map(\.id)))
+            }
+        } else {
+            for item in processed {
+                selectedItemIds.remove(item.id)
+                exampleItemIds.remove(item.id)
+                _hiddenSelectedItems.removeValue(forKey: item.id)
+                _pendingHiddenFetch.remove(item.id)
             }
         }
         markSelectedDirty()
     }
-    
+
     func clearSelection() {
         selectedItemIds.removeAll()
         exampleItemIds.removeAll()
@@ -267,6 +487,9 @@ final class ContentManager {
         if sources["clipboard"] is ClipboardSource {
             History.shared.items.forEach { $0.isSelected = false }
         }
+        _hiddenSelectedItems.removeAll()
+        _pendingHiddenFetch.removeAll()
+        _folderSelectionExclusions.removeAll()
         markSelectedDirty()
     }
     
@@ -277,15 +500,20 @@ final class ContentManager {
     // - It is a file inside any selected folder (use path prefix check)
     func isSelected(effectively item: ContentItem) -> Bool {
         if selectedItemIds.contains(item.id) { return true }
-        guard item.sourceType == .folder, let itemPath = item.fileURL?.path else { return false }
+        if _folderSelectionExclusions[item.id] != nil { return false }
+        guard item.sourceType == .folder,
+              let rawPath = item.fileURL?.path else { return false }
+        let normalizedPath = item.isFolder ? normalizedFolderPath(rawPath) : rawPath
+        if hasDeselectionOverride(forPath: normalizedPath, excluding: item.id) { return false }
         // Any selected folder that is an ancestor of this item implies effective selection
         for fid in selectedItemIds {
             if let folder = self.item(for: fid),
                folder.isFolder,
-               let folderPath = folder.fileURL?.path,
-               itemPath.hasPrefix(folderPath.hasSuffix("/") ? folderPath : folderPath + "/") {
-                // Ensure not the folder itself
-                if folder.id != item.id { return true }
+               let folderRawPath = folder.fileURL?.path {
+                let folderPath = normalizedFolderPath(folderRawPath)
+                if folder.id != item.id, normalizedPath.hasPrefix(folderPath) {
+                    return true
+                }
             }
         }
         return false
@@ -294,50 +522,59 @@ final class ContentManager {
     func getFolderSelectionState(_ folderId: UUID) -> FolderSelectionState {
         guard let folderItem = item(for: folderId),
               folderItem.isFolder,
-              let folderPath = folderItem.fileURL?.path else { return .none }
+              let source = sources[folderItem.sourceId] else { return .none }
 
-        guard let sourceItems = _itemsBySource[folderItem.sourceId] else { return .none }
-
-        // Get all visible children of this folder
-        let children = sourceItems.filter { $0.parentPath == folderPath }
+        let children = visibleChildItems(of: folderItem)
 
         // If folder is collapsed (no visible children), compute state from real descendants on disk
         if children.isEmpty {
-            let urls = enumerateDescendantFiles(at: URL(fileURLWithPath: folderPath))
-            guard !urls.isEmpty else { return .none }
-            let selectedCount = urls.reduce(0) { acc, url in
-                let id = stableUUID(for: url)
-                return acc + (selectedItemIds.contains(id) ? 1 : 0)
+            guard let hierarchical = source as? HierarchicalContentSource else {
+                return .none
             }
+
+            let snapshot = hierarchical.descendantSnapshot(for: folderId)
+            guard !snapshot.itemIds.isEmpty else { return .none }
+
+            let selectedCount = snapshot.itemIds.reduce(into: 0) { count, id in
+                if selectedItemIds.contains(id) { count += 1 }
+            }
+
             if selectedCount == 0 { return .none }
-            if selectedCount == urls.count { return .all }
+            if selectedCount == snapshot.itemIds.count { return .all }
             return .partial
         }
         
-        // For expanded folders, calculate based on children selection (only count files, not subfolders)
+        // For expanded folders, calculate based on per-child state so mixed selections stay accurate
         let fileChildren = children.filter { !$0.isFolder }
-        let selectedFileChildren = fileChildren.filter { selectedItemIds.contains($0.id) }
-        
-        // Also need to check if any subfolders have selected descendants
         let subfolders = children.filter { $0.isFolder }
-        var hasSelectedInSubfolders = false
-        for subfolder in subfolders {
-            if getFolderSelectionState(subfolder.id) != .none {
-                hasSelectedInSubfolders = true
-                break
+
+        var anySelection = false
+        var allFullySelected = true
+
+        // Files are fully selected only when their UUID is tracked in the selection set
+        for file in fileChildren {
+            if selectedItemIds.contains(file.id) {
+                anySelection = true
+            } else {
+                allFullySelected = false
             }
         }
-        
-        let totalSelected = selectedFileChildren.count + (hasSelectedInSubfolders ? 1 : 0)
-        let totalItems = fileChildren.count + (subfolders.isEmpty ? 0 : 1)
-        
-        if totalSelected == 0 {
-            return .none
-        } else if totalSelected == totalItems && selectedFileChildren.count == fileChildren.count {
-            return .all
-        } else {
-            return .partial
+
+        // Subfolders inherit their own state; aggregate precisely instead of collapsing to a single flag
+        for subfolder in subfolders {
+            switch getFolderSelectionState(subfolder.id) {
+            case .all:
+                anySelection = true
+            case .partial:
+                anySelection = true
+                allFullySelected = false
+            case .none:
+                allFullySelected = false
+            }
         }
+
+        guard anySelection else { return .none }
+        return allFullySelected ? .all : .partial
     }
     
     func focus(_ id: UUID?) {
@@ -437,7 +674,10 @@ final class ContentManager {
            sourceItems.contains(where: { $0.id == focusedId }) {
             focusedItemId = nil
         }
-        
+
+        // Clear hidden caches tied to this source
+        clearHiddenSelections(for: sourceId)
+
         // For folder sources, also remove the bookmark
         if source.type == .folder {
             // Prefer obtaining the exact URL from FileSystemSource
@@ -507,7 +747,7 @@ final class ContentManager {
     func markDecoratorsNeedRefresh(for sourceId: String) {
         _decoratorCacheDirty.insert(sourceId)
     }
-    
+
     // Clear decorator cache for a source (when source is removed)
     func clearDecoratorCache(for sourceId: String) {
         _decoratorCache.removeValue(forKey: sourceId)
@@ -605,6 +845,8 @@ final class ContentManager {
                 let childIDs = descendantTextItemIDs(for: item)
                 for cid in childIDs {
                     exampleItemIds.remove(cid)
+                    _hiddenSelectedItems.removeValue(forKey: cid)
+                    _pendingHiddenFetch.remove(cid)
                 }
             }
         } else {
@@ -617,6 +859,9 @@ final class ContentManager {
                     selectedItemIds.insert(cid)
                     exampleItemIds.insert(cid)
                 }
+                if !childIDs.isEmpty {
+                    scheduleHiddenSelectionPrefetch(for: Set(childIDs))
+                }
             }
         }
         markSelectedDirty()
@@ -624,52 +869,33 @@ final class ContentManager {
     
     // Collect all textual descendant file UUIDs for a folder item by scanning the filesystem
     private func descendantTextItemIDs(for folder: ContentItem) -> [UUID] {
-        guard folder.isFolder, let baseURL = folder.fileURL else { return [] }
-        let fileURLs = self.enumerateDescendantFiles(at: baseURL)
-        var ids: [UUID] = []
-        for url in fileURLs {
-            if isTextURL(url) {
-                let id = stableUUID(for: url)
-                ids.append(id)
-            }
-        }
-        return ids
+        guard folder.isFolder,
+              let source = sources[folder.sourceId] as? HierarchicalContentSource else { return [] }
+        return source.descendantSnapshot(for: folder.id).textItemIds
     }
-    
-    // File enumeration helpers
-    nonisolated private func enumerateDescendantFiles(at baseURL: URL) -> [URL] {
-        var results: [URL] = []
-        let fm = FileManager.default
-        if let enumerator = fm.enumerator(at: baseURL, includingPropertiesForKeys: [.isDirectoryKey, .contentTypeKey], options: [.skipsHiddenFiles]) {
-            for case let url as URL in enumerator {
-                do {
-                    let vals = try url.resourceValues(forKeys: [.isDirectoryKey])
-                    if vals.isDirectory == true { continue }
-                    results.append(url)
-                } catch {
-                    continue
-                }
+
+    private func visibleChildItems(of folder: ContentItem) -> [ContentItem] {
+        if let hierarchical = sources[folder.sourceId] as? HierarchicalContentSource {
+            return hierarchical.visibleChildren(of: folder.id)
+        }
+
+        guard let sourceItems = sources[folder.sourceId]?.items,
+              let startIndex = sourceItems.firstIndex(where: { $0.id == folder.id }) else { return [] }
+
+        let childDepth = folder.depth + 1
+        var results: [ContentItem] = []
+        var index = startIndex + 1
+
+        while index < sourceItems.count {
+            let item = sourceItems[index]
+            if item.depth <= folder.depth { break }
+            if item.depth == childDepth {
+                results.append(item)
             }
+            index += 1
         }
         return results
     }
-    
-    private func isTextURL(_ url: URL) -> Bool {
-        let type = FileSystemSource.resolvedType(for: url)
-        if type?.conforms(to: .text) == true { return true }
-        if type == .rtf || type == .rtfd || type == .html { return true }
-        // Markdown special cases
-        if type?.identifier == "net.daringfireball.markdown" ||
-           type?.identifier == "public.markdown" ||
-           type?.preferredFilenameExtension == "md" { return true }
-        return false
-    }
-    
-    nonisolated func stableUUID(for url: URL) -> UUID {
-        let snap = FileIdentity.snapshot(for: url)
-        return FileSystemSource.makeStableUUID(identity: snap.identity, fallbackPath: url.absoluteString)
-    }
-    
     func canToggleExample(_ id: UUID) -> Bool {
         guard selectedItemIds.contains(id),
               item(for: id) != nil else { return false }
@@ -682,11 +908,10 @@ final class ContentManager {
         
         if item.isFolder {
             // Allow folder examples only if all descendant files are textual and there is at least one file
-            guard let baseURL = item.fileURL else { return false }
-            let files = enumerateDescendantFiles(at: baseURL)
-            let textual = files.filter { isTextURL($0) }
-            guard !files.isEmpty else { return false }
-            return files.count == textual.count
+            guard let source = sources[item.sourceId] as? HierarchicalContentSource else { return false }
+            let snapshot = source.descendantSnapshot(for: item.id)
+            guard !snapshot.isEmpty else { return false }
+            return snapshot.items.allSatisfy { $0.isText }
         }
         
         // Disallow media or non-text files as examples
@@ -748,70 +973,152 @@ extension ContentManager {
         let hiddenSelectedIds = selectedItemIds.subtracting(visibleIds)
 
         if !hiddenSelectedIds.isEmpty {
-            // Check each source for selected items that might be hidden (files in collapsed folders)
-            for sourceId in orderedSourceIds {
-                guard let source = sources[sourceId] as? FileSystemSource else { continue }
+            let cachedHidden = hiddenSelectedIds.compactMap { _hiddenSelectedItems[$0] }
+            if !cachedHidden.isEmpty {
+                hiddenSelectedItems.append(contentsOf: cachedHidden.filter { !$0.isFolder })
+            }
 
-                // Scan the filesystem to find these hidden selected files
-                let foundItems = source.findItemsById(hiddenSelectedIds)
-                hiddenSelectedItems.append(contentsOf: foundItems.filter { !$0.isFolder })
+            let cachedIds = Set(cachedHidden.map { $0.id })
+            let missingHidden = hiddenSelectedIds.subtracting(cachedIds)
+            if !missingHidden.isEmpty {
+                scheduleHiddenSelectionPrefetch(for: missingHidden)
             }
         }
 
         // Combine visible and hidden selected items
         let allItemsIncludingHidden = items + hiddenSelectedItems
 
-        // Index folders by path for fast parent lookup
+        // Index folders and children once to avoid repeated scans when building the result
         var folderByPath: [String: ContentItem] = [:]
+        var childrenByParent: [String: [ContentItem]] = [:]
         folderByPath.reserveCapacity(allItemsIncludingHidden.count)
-        for item in allItemsIncludingHidden where item.isFolder {
-            if let path = item.fileURL?.path { folderByPath[path] = item }
+
+        for item in allItemsIncludingHidden {
+            if item.isFolder, let path = item.fileURL?.path {
+                folderByPath[path] = item
+            }
+            if let parentPath = item.parentPath {
+                childrenByParent[parentPath, default: []].append(item)
+            }
         }
-        
+
         // Determine which parent folders need to be included for display due to selected children
         var neededParentIds: Set<UUID> = []
-        for item in allItemsIncludingHidden {
-            guard selectedItemIds.contains(item.id) else { continue }
-            if let parentPath = item.parentPath, let parent = folderByPath[parentPath] {
+        for item in allItemsIncludingHidden where selectedItemIds.contains(item.id) {
+            if let parentPath = item.parentPath,
+               let parent = folderByPath[parentPath] {
                 neededParentIds.insert(parent.id)
             }
         }
-        
+
         // Build result with hierarchical grouping: parent folders followed by their selected children
         var result: [ContentItem] = []
         result.reserveCapacity(selectedItemIds.count + neededParentIds.count)
         var seen: Set<UUID> = []
 
-        // Process items in hierarchical order: folders followed by their children
         for item in allItemsIncludingHidden {
-            // Add parent folders that need to be shown for context
-            if item.isFolder && neededParentIds.contains(item.id) {
-                if !seen.contains(item.id) {
-                    result.append(item)
-                    seen.insert(item.id)
+            if item.isFolder,
+               neededParentIds.contains(item.id),
+               !seen.contains(item.id) {
+                result.append(item)
+                seen.insert(item.id)
 
-                    // Immediately add children of this folder that are selected
-                    let folderPath = item.fileURL?.path
-                    for childItem in allItemsIncludingHidden {
-                        if selectedItemIds.contains(childItem.id) && 
-                           !seen.contains(childItem.id) && 
-                           childItem.parentPath == folderPath {
-                            result.append(childItem)
-                            seen.insert(childItem.id)
-                        }
+                if let folderPath = item.fileURL?.path,
+                   let children = childrenByParent[folderPath] {
+                    for child in children where selectedItemIds.contains(child.id) && !seen.contains(child.id) {
+                        result.append(child)
+                        seen.insert(child.id)
                     }
                 }
+                continue
             }
-        }
-        
-        // Add any remaining selected items that don't have a parent (e.g., clipboard items)
-        for item in allItemsIncludingHidden {
+
             if selectedItemIds.contains(item.id) && !seen.contains(item.id) {
                 result.append(item)
                 seen.insert(item.id)
             }
         }
-        
+
         return result
     }
 }
+
+extension ContentManager {
+    private func scheduleHiddenSelectionPrefetch(for ids: Set<UUID>) {
+        let newRequests = ids.subtracting(_pendingHiddenFetch)
+        guard !newRequests.isEmpty else { return }
+
+        _pendingHiddenFetch.formUnion(newRequests)
+
+        Task.detached(priority: .utility) { [weak self] in
+            guard let self else { return }
+
+            var remaining = newRequests
+            let sourceIds: [String] = await MainActor.run {
+                self.sources.compactMap { key, value in
+                    (value is HierarchicalContentSource) ? key : nil
+                }
+            }
+
+            for sourceId in sourceIds {
+                guard !remaining.isEmpty else { break }
+                let found = await self.resolveItemsOnMain(for: remaining, sourceId: sourceId)
+                guard !found.isEmpty else { continue }
+
+                let foundIds = Set(found.map { $0.id })
+                remaining.subtract(foundIds)
+
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    for item in found {
+                        self._hiddenSelectedItems[item.id] = item
+                    }
+                    self._pendingHiddenFetch.subtract(foundIds)
+
+                    // Only trigger a refresh if any of the resolved IDs are still selected
+                    if !foundIds.isDisjoint(with: self.selectedItemIds) {
+                        self.markSelectedDirty()
+                    }
+                }
+            }
+
+            if !remaining.isEmpty {
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    self._pendingHiddenFetch.subtract(remaining)
+                }
+            }
+        }
+    }
+}
+
+#if DEBUG
+extension ContentManager {
+    func resetForTesting() {
+        sources.values.forEach { $0.stopMonitoring() }
+        sources.removeAll()
+        orderedSourceIds.removeAll()
+        activeSourceId = "clipboard"
+        lastNonPromptsSourceId = "clipboard"
+
+        selectedItemIds.removeAll()
+        exampleItemIds.removeAll()
+        selectionVersion = 0
+        focusedItemId = nil
+        renameActiveItemId = nil
+        pendingRenameItemId = nil
+        promptEditorText = ""
+        isPromptEditorEditing = false
+        enhanceButtonClicked = false
+
+        _selectedCache.removeAll()
+        _selectedCacheDirty = true
+        _decoratorCache.removeAll()
+        _decoratorCacheDirty.removeAll()
+        _hiddenSelectedItems.removeAll()
+        _pendingHiddenFetch.removeAll()
+        _folderSelectionExclusions.removeAll()
+        _descendantSelectionTokens.removeAll()
+    }
+}
+#endif

--- a/nozzle/Observables/FileSystemSource.swift
+++ b/nozzle/Observables/FileSystemSource.swift
@@ -546,7 +546,7 @@ final class FileSystemSource: ContentSource, HierarchicalContentSource {
                 let timestamp = values.contentModificationDate ?? Date()
                 let uniformType = values.contentType?.identifier ?? (isDirectory ? nil : Self.resolvedType(for: url)?.identifier)
                 let relativePath = url.path.replacingOccurrences(of: baseURL.path + "/", with: "")
-                let depth = relativePath.components(separatedBy: "/").count
+                let depth = max(0, relativePath.components(separatedBy: "/").count - 1)
                 let parentPath = url.deletingLastPathComponent().path
 
                 let item = ContentItem(

--- a/nozzle/Observables/FileSystemSource.swift
+++ b/nozzle/Observables/FileSystemSource.swift
@@ -2,6 +2,7 @@ import AppKit
 import UniformTypeIdentifiers
 import Observation
 import CoreServices
+import OSLog
 import Defaults
 
 // MARK: - Sorting Enums
@@ -19,7 +20,16 @@ enum FileSortDirection: String, CaseIterable {
 }
 
 @Observable @MainActor
-final class FileSystemSource: ContentSource {
+final class FileSystemSource: ContentSource, HierarchicalContentSource {
+    private static let refreshLogger = Logger(subsystem: "org.conmeara.nozzle.content", category: "FileSystemSource")
+    private static let directoryResourceKeys: Set<URLResourceKey> = [
+        .isDirectoryKey,
+        .contentModificationDateKey,
+        .fileSizeKey,
+        .fileResourceIdentifierKey,
+        .contentTypeKey
+    ]
+
     nonisolated let id: String  // Need nonisolated access for event persistence
     let name: String
     let icon: NSImage
@@ -65,6 +75,7 @@ final class FileSystemSource: ContentSource {
     // Fast lookup for rename/move resolution
     private var indexByIdentity: [Data: Int] = [:]
     private var indexByPath: [String: Int] = [:]
+    private var indexById: [UUID: Int] = [:]
     
     // Resort suspension for stable editing
     private var suspendResortItemId: UUID?
@@ -74,6 +85,42 @@ final class FileSystemSource: ContentSource {
         let snapshot: FileIdentity.Snapshot
         let typeIdentifier: String?
     }
+
+    private struct DescendantSnapshotCacheEntry {
+        let items: [HierarchyDescendantItem]
+        let modificationDate: Date
+    }
+
+    private final class DescendantCacheStore: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [String: DescendantSnapshotCacheEntry] = [:]
+
+        func entry(for path: String) -> DescendantSnapshotCacheEntry? {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage[path]
+        }
+
+        func store(_ entry: DescendantSnapshotCacheEntry, for path: String) {
+            lock.lock()
+            storage[path] = entry
+            lock.unlock()
+        }
+
+        func removeAll() {
+            lock.lock()
+            storage.removeAll()
+            lock.unlock()
+        }
+
+        func remove(prefix: String) {
+            lock.lock()
+            storage = storage.filter { !$0.key.hasPrefix(prefix) }
+            lock.unlock()
+        }
+    }
+
+    private let descendantCache = DescendantCacheStore()
     
     init(folderURL: URL) {
         self.folderURL = folderURL
@@ -88,7 +135,46 @@ final class FileSystemSource: ContentSource {
         if searchQuery.isEmpty { return cachedItems }
         return search(query: searchQuery)
     }
-    
+
+    func item(with id: UUID) -> ContentItem? {
+        if let index = indexById[id], cachedItems.indices.contains(index) {
+            return cachedItems[index]
+        }
+        return nil
+    }
+
+    func visibleChildren(of folderId: UUID) -> [ContentItem] {
+        guard let folderIndex = indexById[folderId],
+              cachedItems.indices.contains(folderIndex) else { return [] }
+
+        let parent = cachedItems[folderIndex]
+        guard parent.isFolder else { return [] }
+
+        let childDepth = parent.depth + 1
+        var result: [ContentItem] = []
+        var i = folderIndex + 1
+
+        while i < cachedItems.count {
+            let candidate = cachedItems[i]
+            if candidate.depth <= parent.depth { break }
+            if candidate.depth == childDepth {
+                result.append(candidate)
+            }
+            i += 1
+        }
+
+        return result
+    }
+
+    func descendantSnapshot(for folderId: UUID) -> HierarchyDescendantSnapshot {
+        guard let folderItem = item(with: folderId),
+              let folderURL = folderItem.fileURL else {
+            return HierarchyDescendantSnapshot(items: [])
+        }
+
+        return descendantSnapshot(for: folderURL)
+    }
+
     func startMonitoring() {
         guard !isMonitoring else { return }
         
@@ -160,15 +246,26 @@ final class FileSystemSource: ContentSource {
     private func forceRefresh() async {
         // Mark decorators as needing refresh before updating items
         ContentManager.shared.markDecoratorsNeedRefresh(for: self.id)
-        
+
+#if DEBUG
+        let refreshStart = Date()
+#endif
+
         // Build hierarchical structure starting from root
         let hierarchicalItems = await buildHierarchicalItems(at: folderURL, depth: 0, parentPath: nil)
         self.cachedItems = hierarchicalItems
         self.lastRefreshTime = Date()
         self.rebuildIndexes()
         ContentManager.shared.markItemsDirty()
+        ContentManager.shared.clearHiddenSelections(for: self.id, underPath: folderURL.path)
         // Visible slice changed; invalidate selectedItems cache
         ContentManager.shared.markSelectedDirty()
+        invalidateDescendantCache(under: folderURL.path)
+
+#if DEBUG
+        let elapsed = Date().timeIntervalSince(refreshStart)
+        Self.refreshLogger.debug("forceRefresh(\(self.folderURL.lastPathComponent, privacy: .public)) duration=\(elapsed, privacy: .public)s items=\(hierarchicalItems.count, privacy: .public)")
+#endif
     }
     
     // Check if directory has been modified since last cache
@@ -204,9 +301,13 @@ final class FileSystemSource: ContentSource {
             directoryModDateCache = directoryModDateCache.filter { cachedPath, _ in
                 !cachedPath.hasPrefix(specificPath)
             }
+            invalidateDescendantCache(under: specificPath)
+            ContentManager.shared.clearHiddenSelections(for: id, underPath: specificPath)
         } else {
             // Clear entire cache
             directoryModDateCache.removeAll()
+            invalidateDescendantCache(under: folderURL.path)
+            ContentManager.shared.clearHiddenSelections(for: id, underPath: folderURL.path)
         }
     }
 
@@ -253,6 +354,8 @@ final class FileSystemSource: ContentSource {
         // Visible slice changed; invalidate selectedItems cache and decorators cache
         ContentManager.shared.markDecoratorsNeedRefresh(for: self.id)
         ContentManager.shared.markSelectedDirty()
+        invalidateDescendantCache(under: folderPath)
+        ContentManager.shared.clearHiddenSelections(for: self.id, underPath: folderPath)
     }
 
     @MainActor
@@ -267,7 +370,12 @@ final class FileSystemSource: ContentSource {
         return nil
     }
     
-    private func buildHierarchicalItems(at url: URL, depth: Int, parentPath: String?) async -> [ContentItem] {
+    private func buildHierarchicalItems(
+        at url: URL,
+        depth: Int,
+        parentPath: String?,
+        expandedPaths: Set<String>? = nil
+    ) async -> [ContentItem] {
         // Check if directory has changed before expensive scanning
         let hasChanged = await MainActor.run { self.hasDirectoryChanged(at: url) }
 
@@ -277,14 +385,22 @@ final class FileSystemSource: ContentSource {
             return await MainActor.run { self.cachedItems }
         }
 
+        let expandedSet: Set<String>
+        if let expandedPaths {
+            expandedSet = expandedPaths
+        } else {
+            expandedSet = await MainActor.run { self.expansionState.getAllExpandedPaths() }
+        }
+
         let (sortOrder, sortDirection) = await MainActor.run { (self.sortOrder, self.sortDirection) }
         let sourceId = "folder:\(self.folderURL.path)"
 
+        let resourceKeys = Self.directoryResourceKeys
         let task = Task.detached { () -> [ContentItem] in
             let fm = FileManager.default
             guard let urls = try? fm.contentsOfDirectory(
                 at: url,
-                includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey, .fileSizeKey, .fileResourceIdentifierKey],
+                includingPropertiesForKeys: Array(resourceKeys),
                 options: [.skipsHiddenFiles]
             ) else { return [] }
 
@@ -298,11 +414,23 @@ final class FileSystemSource: ContentSource {
                     continue
                 }
 
-                let snapshot = FileIdentity.snapshot(for: itemURL)
+                guard let resourceValues = try? itemURL.resourceValues(forKeys: resourceKeys) else { continue }
+                let snapshot = FileIdentity.Snapshot(
+                    identity: resourceValues.fileResourceIdentifier as? Data,
+                    modDate: resourceValues.contentModificationDate ?? .distantPast,
+                    isDirectory: resourceValues.isDirectory ?? false,
+                    size: resourceValues.fileSize.map { Int64($0) }
+                )
+
                 if snapshot.isDirectory {
                     folders.append(DirectoryEntry(url: itemURL, snapshot: snapshot, typeIdentifier: nil))
                 } else {
-                    let typeIdentifier = Self.resolvedType(for: itemURL)?.identifier
+                    let typeIdentifier: String?
+                    if let type = resourceValues.contentType {
+                        typeIdentifier = type.identifier
+                    } else {
+                        typeIdentifier = Self.resolvedType(for: itemURL)?.identifier
+                    }
                     files.append(DirectoryEntry(url: itemURL, snapshot: snapshot, typeIdentifier: typeIdentifier))
                 }
             }
@@ -363,24 +491,18 @@ final class FileSystemSource: ContentSource {
             // If it's a folder and should be expanded, add its children
             if item.isFolder,
                let folderURL = item.fileURL,
-               depth < 3 { // Max depth limit
-                
-                // Check if this folder is expanded
-                let shouldExpand = await MainActor.run {
-                    return self.expansionState.isExpanded(folderURL.path)
-                }
-                
-                if shouldExpand {
-                    let childItems = await buildHierarchicalItems(
-                        at: folderURL,
-                        depth: depth + 1,
-                        parentPath: folderURL.path
-                    )
-                    allItems.append(contentsOf: childItems)
-                }
+               depth < 3,
+               expandedSet.contains(folderURL.path) {
+                let childItems = await buildHierarchicalItems(
+                    at: folderURL,
+                    depth: depth + 1,
+                    parentPath: folderURL.path,
+                    expandedPaths: expandedSet
+                )
+                allItems.append(contentsOf: childItems)
             }
         }
-        
+
         // Update directory modification date cache after successful scan
         await MainActor.run {
             self.updateDirectoryModDateCache(at: url)
@@ -397,64 +519,59 @@ final class FileSystemSource: ContentSource {
     }
     
     // Find items by their IDs, even if they're not currently visible (collapsed folders)
-    func findItemsById(_ ids: Set<UUID>) -> [ContentItem] {
+    func resolveItems(for ids: Set<UUID>) async -> [ContentItem] {
         guard !ids.isEmpty else { return [] }
-        
-        var foundItems: [ContentItem] = []
-        let fm = FileManager.default
-        
-        // Recursively scan the folder to find matching items
-        if let enumerator = fm.enumerator(
-            at: folderURL,
-            includingPropertiesForKeys: [.isDirectoryKey, .contentTypeKey, .contentModificationDateKey, .fileSizeKey],
-            options: [.skipsHiddenFiles]
-        ) {
-            for case let url as URL in enumerator {
-                // Generate stable UUID for this URL
-                let itemId = Self.makeStableUUID(
-                    identity: FileIdentity.snapshot(for: url).identity,
-                    fallbackPath: url.absoluteString
+
+        let baseURL = folderURL
+        let sourceId = self.id
+        let resourceKeys = Self.directoryResourceKeys
+
+        return await Task.detached(priority: .utility) { () -> [ContentItem] in
+            var foundItems: [ContentItem] = []
+            let fm = FileManager.default
+
+            guard let enumerator = fm.enumerator(
+                at: baseURL,
+                includingPropertiesForKeys: Array(resourceKeys),
+                options: [.skipsHiddenFiles]
+            ) else { return [] }
+
+            while let url = enumerator.nextObject() as? URL {
+                guard let values = try? url.resourceValues(forKeys: resourceKeys) else { continue }
+                let identity = values.fileResourceIdentifier as? Data
+                let itemId = Self.makeStableUUID(identity: identity, fallbackPath: url.absoluteString)
+                guard ids.contains(itemId) else { continue }
+
+                let isDirectory = values.isDirectory == true
+                let timestamp = values.contentModificationDate ?? Date()
+                let uniformType = values.contentType?.identifier ?? (isDirectory ? nil : Self.resolvedType(for: url)?.identifier)
+                let relativePath = url.path.replacingOccurrences(of: baseURL.path + "/", with: "")
+                let depth = relativePath.components(separatedBy: "/").count
+                let parentPath = url.deletingLastPathComponent().path
+
+                let item = ContentItem(
+                    id: itemId,
+                    title: url.lastPathComponent,
+                    timestamp: timestamp,
+                    sourceType: .folder,
+                    sourceId: sourceId,
+                    fileURL: url,
+                    uniformTypeIdentifier: uniformType,
+                    fileSize: values.fileSize.map { Int64($0) },
+                    isFolder: isDirectory,
+                    depth: depth,
+                    parentPath: parentPath == baseURL.path ? nil : parentPath,
+                    isSelected: true
                 )
-                
-                // Check if this ID is one we're looking for
-                if ids.contains(itemId) {
-                    do {
-                        let vals = try url.resourceValues(forKeys: [.isDirectoryKey, .contentTypeKey, .contentModificationDateKey, .fileSizeKey])
-                        
-                        // Calculate depth and parent path
-                        let relativePath = url.path.replacingOccurrences(of: folderURL.path + "/", with: "")
-                        let depth = relativePath.components(separatedBy: "/").count
-                        let parentPath = url.deletingLastPathComponent().path
-                        
-                        let contentItem = ContentItem(
-                            id: itemId,
-                            title: url.lastPathComponent,
-                            timestamp: vals.contentModificationDate ?? Date(),
-                            sourceType: .folder,
-                            sourceId: self.id,
-                            fileURL: url,
-                            uniformTypeIdentifier: vals.contentType?.identifier,
-                            fileSize: Int64(vals.fileSize ?? 0),
-                            isFolder: vals.isDirectory == true,
-                            depth: depth,
-                            parentPath: parentPath == folderURL.path ? nil : parentPath,
-                            isSelected: true // These are selected items
-                        )
-                        
-                        foundItems.append(contentItem)
-                        
-                        // Stop early if we've found all items
-                        if foundItems.count == ids.count {
-                            break
-                        }
-                    } catch {
-                        continue
-                    }
+                foundItems.append(item)
+
+                if foundItems.count == ids.count {
+                    break
                 }
             }
-        }
-        
-        return foundItems
+
+            return foundItems
+        }.value
     }
     
     // MARK: - Folder expansion methods
@@ -484,6 +601,65 @@ final class FileSystemSource: ContentSource {
         Task {
             await forceRefresh()  // Force refresh when user explicitly changes sort
         }
+    }
+
+    private func invalidateDescendantCache(under path: String? = nil) {
+        guard let path = path, !path.isEmpty else {
+            descendantCache.removeAll()
+            return
+        }
+
+        descendantCache.remove(prefix: normalizedFolderPath(path))
+    }
+
+    private nonisolated func isTextType(_ type: UTType?) -> Bool {
+        guard let type else { return false }
+        if type.conforms(to: .text) { return true }
+        if type == .rtf || type == .rtfd || type == .html { return true }
+        if type.identifier == "net.daringfireball.markdown" ||
+            type.identifier == "public.markdown" ||
+            type.preferredFilenameExtension == "md" {
+            return true
+        }
+        return false
+    }
+
+    private nonisolated func descendantSnapshot(for folderURL: URL) -> HierarchyDescendantSnapshot {
+        let folderPath = normalizedFolderPath(folderURL.path)
+        let modDate = (try? folderURL.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+
+        if let cached = descendantCache.entry(for: folderPath), cached.modificationDate == modDate {
+            return HierarchyDescendantSnapshot(items: cached.items)
+        }
+
+        var descendants: [HierarchyDescendantItem] = []
+        let fm = FileManager.default
+        if let enumerator = fm.enumerator(at: folderURL, includingPropertiesForKeys: [.isDirectoryKey, .contentTypeKey, .fileResourceIdentifierKey], options: [.skipsHiddenFiles]) {
+            for case let url as URL in enumerator {
+                do {
+                    let values = try url.resourceValues(forKeys: [.isDirectoryKey, .contentTypeKey, .fileResourceIdentifierKey])
+                    if values.isDirectory == true { continue }
+                    let type = values.contentType ?? Self.resolvedType(for: url)
+                    let snapshot = FileIdentity.snapshot(for: url)
+                    let id = Self.makeStableUUID(identity: snapshot.identity, fallbackPath: url.absoluteString)
+                    let isText = isTextType(type)
+                    descendants.append(HierarchyDescendantItem(id: id, path: url.path, isText: isText))
+                } catch {
+                    continue
+                }
+            }
+        }
+
+        descendantCache.store(
+            DescendantSnapshotCacheEntry(items: descendants, modificationDate: modDate),
+            for: folderPath
+        )
+
+        return HierarchyDescendantSnapshot(items: descendants)
+    }
+
+    private nonisolated func normalizedFolderPath(_ path: String) -> String {
+        path.hasSuffix("/") ? path : path + "/"
     }
     
     private nonisolated static func sortEntries(_ lhs: DirectoryEntry, _ rhs: DirectoryEntry, order: FileSortOrder, direction: FileSortDirection) -> Bool {
@@ -651,7 +827,8 @@ extension FileSystemSource {
     private func rebuildIndexes() {
         indexByIdentity.removeAll()
         indexByPath.removeAll()
-        
+        indexById.removeAll()
+
         for (i, item) in cachedItems.enumerated() {
             if let identity = item.fileIdentity {
                 indexByIdentity[identity] = i
@@ -659,6 +836,7 @@ extension FileSystemSource {
             if let path = item.fileURL?.path {
                 indexByPath[path] = i
             }
+            indexById[item.id] = i
         }
     }
     

--- a/nozzle/Observables/FileSystemSource.swift
+++ b/nozzle/Observables/FileSystemSource.swift
@@ -638,12 +638,18 @@ final class FileSystemSource: ContentSource, HierarchicalContentSource {
             for case let url as URL in enumerator {
                 do {
                     let values = try url.resourceValues(forKeys: [.isDirectoryKey, .contentTypeKey, .fileResourceIdentifierKey])
-                    if values.isDirectory == true { continue }
                     let type = values.contentType ?? Self.resolvedType(for: url)
                     let snapshot = FileIdentity.snapshot(for: url)
                     let id = Self.makeStableUUID(identity: snapshot.identity, fallbackPath: url.absoluteString)
                     let isText = isTextType(type)
-                    descendants.append(HierarchyDescendantItem(id: id, path: url.path, isText: isText))
+                    descendants.append(
+                        HierarchyDescendantItem(
+                            id: id,
+                            path: url.path,
+                            isText: isText,
+                            isFolder: values.isDirectory == true
+                        )
+                    )
                 } catch {
                     continue
                 }

--- a/nozzleTests/ContentManagerSelectionTests.swift
+++ b/nozzleTests/ContentManagerSelectionTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import nozzle
+
+@MainActor
+final class ContentManagerSelectionTests: XCTestCase {
+    func testHiddenSelectionPrefetchAddsFolderContext() async throws {
+        let manager = ContentManager.shared
+        manager.resetForTesting()
+
+        let tempRoot = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let nestedFolder = tempRoot.appendingPathComponent("Reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: nestedFolder, withIntermediateDirectories: true)
+        let hiddenFile = nestedFolder.appendingPathComponent("january.txt")
+        try "budget".write(to: hiddenFile, atomically: true, encoding: .utf8)
+
+        let source = FileSystemSource(folderURL: tempRoot)
+        manager.registerSource(source)
+        defer {
+            source.stopMonitoring()
+            manager.resetForTesting()
+        }
+
+        await source.refresh()
+
+        XCTAssertFalse(
+            source.items.contains(where: { $0.fileURL == hiddenFile }),
+            "Nested file should stay hidden while folder is collapsed"
+        )
+
+        let hiddenId = stableUUID(for: hiddenFile)
+        manager.toggleSelection(hiddenId)
+
+        var resolvedItem: ContentItem?
+        let deadline = Date().addingTimeInterval(2.0)
+        repeat {
+            if let match = manager.selectedItems.first(where: { $0.id == hiddenId }) {
+                resolvedItem = match
+                break
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        } while Date() < deadline
+
+        XCTAssertNotNil(resolvedItem, "Hidden selection should surface after background fetch")
+        XCTAssertEqual(resolvedItem?.id, hiddenId)
+
+        let folderItem = try XCTUnwrap(manager.selectedItems.first(where: { $0.isFolder }))
+        XCTAssertEqual(folderItem.fileURL?.lastPathComponent, "Reports")
+
+        guard
+            let folderIndex = manager.selectedItems.firstIndex(where: { $0.id == folderItem.id }),
+            let fileIndex = manager.selectedItems.firstIndex(where: { $0.id == hiddenId })
+        else {
+            XCTFail("Expected both folder and file in aggregated selection")
+            return
+        }
+        XCTAssertLessThan(folderIndex, fileIndex)
+        XCTAssertEqual(manager.selectedItems[fileIndex].id, hiddenId)
+
+        // Rename the hidden file and ensure the cached selection refreshes
+        let renamedURL = nestedFolder.appendingPathComponent("february.txt")
+        try FileManager.default.moveItem(at: hiddenFile, to: renamedURL)
+
+        await source.refresh()
+
+        let renameDeadline = Date().addingTimeInterval(2.0)
+        var refreshedTitle: String?
+        repeat {
+            if let match = manager.selectedItems.first(where: { $0.id == hiddenId }) {
+                if match.title == "february.txt" {
+                    refreshedTitle = match.title
+                    break
+                }
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        } while Date() < renameDeadline
+
+        XCTAssertEqual(refreshedTitle, "february.txt", "Renamed hidden selection should refresh cached metadata")
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "ContentManagerSelectionTests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func stableUUID(for url: URL) -> UUID {
+        let snapshot = FileIdentity.snapshot(for: url)
+        return FileSystemSource.makeStableUUID(identity: snapshot.identity, fallbackPath: url.absoluteString)
+    }
+}


### PR DESCRIPTION
## Summary
- shift hierarchical selection responsibilities into source layer to eliminate global caches
- expose content source snapshot APIs and update ContentManager to consume them
- refresh folder selection tests and verify build via Command line invocation:
    /Applications/Xcode-beta.app/Contents/Developer/usr/bin/xcodebuild -project nozzle.xcodeproj -scheme nozzle build

Resolve Package Graph


Resolved source packages:
  Defaults: https://github.com/sindresorhus/Defaults @ 8.2.0
  Sauce: https://github.com/Clipy/Sauce @ 2.4.1
  KeyboardShortcuts: https://github.com/sindresorhus/KeyboardShortcuts @ 2.0.2
  SwiftHEXColors: https://github.com/thii/SwiftHEXColors @ 1.4.1
  Settings: https://github.com/sindresorhus/Settings.git @ 3.1.1
  LaunchAtLogin: https://github.com/sindresorhus/LaunchAtLogin-Modern @ 1.1.0
  Fuse: https://github.com/krisk/fuse-swift @ 1.4.0

ComputePackagePrebuildTargetDependencyGraph

Prepare packages

CreateBuildRequest

SendProjectDescription

CreateBuildOperation

ComputeTargetDependencyGraph
note: Building targets in dependency order
note: Target dependency graph (18 targets)
    Target 'nozzle' in project 'nozzle'
        ➜ Explicit dependency on target 'KeyboardShortcuts' in project 'KeyboardShortcuts'
        ➜ Explicit dependency on target 'Fuse' in project 'Fuse'
        ➜ Explicit dependency on target 'Defaults' in project 'Defaults'
        ➜ Explicit dependency on target 'SwiftHEXColors' in project 'SwiftHEXColors'
        ➜ Explicit dependency on target 'Sauce' in project 'Sauce'
        ➜ Explicit dependency on target 'Settings' in project 'Settings'
        ➜ Explicit dependency on target 'LaunchAtLogin' in project 'LaunchAtLogin'
    Target 'LaunchAtLogin' in project 'LaunchAtLogin'
        ➜ Explicit dependency on target 'LaunchAtLogin' in project 'LaunchAtLogin'
    Target 'LaunchAtLogin' in project 'LaunchAtLogin' (no dependencies)
    Target 'Settings' in project 'Settings'
        ➜ Explicit dependency on target 'Settings' in project 'Settings'
        ➜ Explicit dependency on target 'Settings_Settings' in project 'Settings'
    Target 'Settings' in project 'Settings'
        ➜ Explicit dependency on target 'Settings_Settings' in project 'Settings'
    Target 'Settings_Settings' in project 'Settings' (no dependencies)
    Target 'Sauce' in project 'Sauce'
        ➜ Explicit dependency on target 'Sauce' in project 'Sauce'
    Target 'Sauce' in project 'Sauce' (no dependencies)
    Target 'SwiftHEXColors' in project 'SwiftHEXColors'
        ➜ Explicit dependency on target 'SwiftHEXColors' in project 'SwiftHEXColors'
    Target 'SwiftHEXColors' in project 'SwiftHEXColors' (no dependencies)
    Target 'Defaults' in project 'Defaults'
        ➜ Explicit dependency on target 'Defaults' in project 'Defaults'
        ➜ Explicit dependency on target 'Defaults_Defaults' in project 'Defaults'
    Target 'Defaults' in project 'Defaults'
        ➜ Explicit dependency on target 'Defaults_Defaults' in project 'Defaults'
    Target 'Defaults_Defaults' in project 'Defaults' (no dependencies)
    Target 'Fuse' in project 'Fuse'
        ➜ Explicit dependency on target 'Fuse' in project 'Fuse'
    Target 'Fuse' in project 'Fuse' (no dependencies)
    Target 'KeyboardShortcuts' in project 'KeyboardShortcuts'
        ➜ Explicit dependency on target 'KeyboardShortcuts' in project 'KeyboardShortcuts'
        ➜ Explicit dependency on target 'KeyboardShortcuts_KeyboardShortcuts' in project 'KeyboardShortcuts'
    Target 'KeyboardShortcuts' in project 'KeyboardShortcuts'
        ➜ Explicit dependency on target 'KeyboardShortcuts_KeyboardShortcuts' in project 'KeyboardShortcuts'
    Target 'KeyboardShortcuts_KeyboardShortcuts' in project 'KeyboardShortcuts' (no dependencies)

GatherProvisioningInputs

CreateBuildDescription

ClangStatCache /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk /Users/conmeara/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.0-25A5344a-5d9328ff1a6613a11d359de947506b52.sdkstatcache
    cd /Users/conmeara/conductor/nozzle/.conductor/selection-hierarchy-refine/nozzle.xcodeproj
    /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk -o /Users/conmeara/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.0-25A5344a-5d9328ff1a6613a11d359de947506b52.sdkstatcache

Copy /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/nozzle.app/Contents/Resources/KeyboardShortcuts_KeyboardShortcuts.bundle /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/KeyboardShortcuts_KeyboardShortcuts.bundle (in target 'nozzle' from project 'nozzle')
    cd /Users/conmeara/conductor/nozzle/.conductor/selection-hierarchy-refine
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/KeyboardShortcuts_KeyboardShortcuts.bundle /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/nozzle.app/Contents/Resources

Copy /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/nozzle.app/Contents/Resources/Defaults_Defaults.bundle /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/Defaults_Defaults.bundle (in target 'nozzle' from project 'nozzle')
    cd /Users/conmeara/conductor/nozzle/.conductor/selection-hierarchy-refine
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/Defaults_Defaults.bundle /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/nozzle.app/Contents/Resources

Copy /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/nozzle.app/Contents/Resources/Settings_Settings.bundle /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/Settings_Settings.bundle (in target 'nozzle' from project 'nozzle')
    cd /Users/conmeara/conductor/nozzle/.conductor/selection-hierarchy-refine
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/Settings_Settings.bundle /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/nozzle.app/Contents/Resources

ProcessInfoPlistFile /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/nozzle.app/Contents/Info.plist /Users/conmeara/conductor/nozzle/.conductor/selection-hierarchy-refine/nozzle/Info.plist (in target 'nozzle' from project 'nozzle')
    cd /Users/conmeara/conductor/nozzle/.conductor/selection-hierarchy-refine
    builtin-infoPlistUtility /Users/conmeara/conductor/nozzle/.conductor/selection-hierarchy-refine/nozzle/Info.plist -producttype com.apple.product-type.application -genpkginfo /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/nozzle.app/Contents/PkgInfo -expandbuildsettings -platform macosx -additionalcontentfile /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Intermediates.noindex/nozzle.build/Debug/nozzle.build/assetcatalog_generated_info.plist -scanforprivacyfile /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/nozzle.app/Contents/Resources/Defaults_Defaults.bundle -scanforprivacyfile /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/nozzle.app/Contents/Resources/KeyboardShortcuts_KeyboardShortcuts.bundle -scanforprivacyfile /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/nozzle.app/Contents/Resources/Settings_Settings.bundle -o /Users/conmeara/Library/Developer/Xcode/DerivedData/nozzle-aknvxqebiwuiizgffowsemcogjxo/Build/Products/Debug/nozzle.app/Contents/Info.plist

** BUILD SUCCEEDED **

## Testing
- Command line invocation:
    /Applications/Xcode-beta.app/Contents/Developer/usr/bin/xcodebuild -project nozzle.xcodeproj -scheme nozzle build

Resolve Package Graph


Resolved source packages:
  LaunchAtLogin: https://github.com/sindresorhus/LaunchAtLogin-Modern @ 1.1.0
  Sauce: https://github.com/Clipy/Sauce @ 2.4.1
  Fuse: https://github.com/krisk/fuse-swift @ 1.4.0
  Settings: https://github.com/sindresorhus/Settings.git @ 3.1.1
  SwiftHEXColors: https://github.com/thii/SwiftHEXColors @ 1.4.1
  KeyboardShortcuts: https://github.com/sindresorhus/KeyboardShortcuts @ 2.0.2
  Defaults: https://github.com/sindresorhus/Defaults @ 8.2.0

ComputePackagePrebuildTargetDependencyGraph

Prepare packages

CreateBuildRequest

SendProjectDescription

CreateBuildOperation

ComputeTargetDependencyGraph
note: Building targets in dependency order
note: Target dependency graph (18 targets)
    Target 'nozzle' in project 'nozzle'
        ➜ Explicit dependency on target 'KeyboardShortcuts' in project 'KeyboardShortcuts'
        ➜ Explicit dependency on target 'Fuse' in project 'Fuse'
        ➜ Explicit dependency on target 'Defaults' in project 'Defaults'
        ➜ Explicit dependency on target 'SwiftHEXColors' in project 'SwiftHEXColors'
        ➜ Explicit dependency on target 'Sauce' in project 'Sauce'
        ➜ Explicit dependency on target 'Settings' in project 'Settings'
        ➜ Explicit dependency on target 'LaunchAtLogin' in project 'LaunchAtLogin'
    Target 'LaunchAtLogin' in project 'LaunchAtLogin'
        ➜ Explicit dependency on target 'LaunchAtLogin' in project 'LaunchAtLogin'
    Target 'LaunchAtLogin' in project 'LaunchAtLogin' (no dependencies)
    Target 'Settings' in project 'Settings'
        ➜ Explicit dependency on target 'Settings' in project 'Settings'
        ➜ Explicit dependency on target 'Settings_Settings' in project 'Settings'
    Target 'Settings' in project 'Settings'
        ➜ Explicit dependency on target 'Settings_Settings' in project 'Settings'
    Target 'Settings_Settings' in project 'Settings' (no dependencies)
    Target 'Sauce' in project 'Sauce'
        ➜ Explicit dependency on target 'Sauce' in project 'Sauce'
    Target 'Sauce' in project 'Sauce' (no dependencies)
    Target 'SwiftHEXColors' in project 'SwiftHEXColors'
        ➜ Explicit dependency on target 'SwiftHEXColors' in project 'SwiftHEXColors'
    Target 'SwiftHEXColors' in project 'SwiftHEXColors' (no dependencies)
    Target 'Defaults' in project 'Defaults'
        ➜ Explicit dependency on target 'Defaults' in project 'Defaults'
        ➜ Explicit dependency on target 'Defaults_Defaults' in project 'Defaults'
    Target 'Defaults' in project 'Defaults'
        ➜ Explicit dependency on target 'Defaults_Defaults' in project 'Defaults'
    Target 'Defaults_Defaults' in project 'Defaults' (no dependencies)
    Target 'Fuse' in project 'Fuse'
        ➜ Explicit dependency on target 'Fuse' in project 'Fuse'
    Target 'Fuse' in project 'Fuse' (no dependencies)
    Target 'KeyboardShortcuts' in project 'KeyboardShortcuts'
        ➜ Explicit dependency on target 'KeyboardShortcuts' in project 'KeyboardShortcuts'
        ➜ Explicit dependency on target 'KeyboardShortcuts_KeyboardShortcuts' in project 'KeyboardShortcuts'
    Target 'KeyboardShortcuts' in project 'KeyboardShortcuts'
        ➜ Explicit dependency on target 'KeyboardShortcuts_KeyboardShortcuts' in project 'KeyboardShortcuts'
    Target 'KeyboardShortcuts_KeyboardShortcuts' in project 'KeyboardShortcuts' (no dependencies)

GatherProvisioningInputs

CreateBuildDescription

ClangStatCache /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk /Users/conmeara/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.0-25A5344a-5d9328ff1a6613a11d359de947506b52.sdkstatcache
    cd /Users/conmeara/conductor/nozzle/.conductor/selection-hierarchy-refine/nozzle.xcodeproj
    /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk -o /Users/conmeara/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.0-25A5344a-5d9328ff1a6613a11d359de947506b52.sdkstatcache

** BUILD SUCCEEDED **
