### PR TITLE
Improve tri-state selection handling and caching behavior

### DIFF
--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -141,9 +141,18 @@ final class ContentManager {
 
         guard !keysToRemove.isEmpty else { return }
 
+        var needsPrefetch: Set<UUID> = []
         for id in keysToRemove {
-            _hiddenSelectedItems.removeValue(forKey: id)
-            _pendingHiddenFetch.remove(id)
+            if selectedItemIds.contains(id) {
+                _pendingHiddenFetch.insert(id)
+                needsPrefetch.insert(id)
+            } else {
+                _hiddenSelectedItems.removeValue(forKey: id)
+                _pendingHiddenFetch.remove(id)
+            }
+        }
+        if !needsPrefetch.isEmpty {
+            scheduleHiddenSelectionPrefetch(for: needsPrefetch)
         }
 
         markSelectedDirty()
@@ -376,6 +385,14 @@ final class ContentManager {
             } else if path == override.path {
                 return true
             }
+        }
+        return false
+    }
+
+    private func hasDeselectionOverrideUnder(prefixOf folder: ContentItem) -> Bool {
+        guard let base = normalizedPath(for: folder) else { return false }
+        for (_, override) in _folderSelectionExclusions where override.path.hasPrefix(base) {
+            return true
         }
         return false
     }
@@ -680,15 +697,29 @@ final class ContentManager {
             }
 
             let snapshot = hierarchical.descendantSnapshot(for: folderId)
-            guard !snapshot.itemIds.isEmpty else { return .none }
+            let fileIds = snapshot.items.filter { !$0.isFolder }.map(\.id)
 
-            let selectedCount = snapshot.itemIds.reduce(into: 0) { count, id in
+            guard !fileIds.isEmpty else {
+                return selectedItemIds.contains(folderItem.id) ? .all : .none
+            }
+
+            if selectedItemIds.contains(folderItem.id),
+               !hasDeselectionOverrideUnder(prefixOf: folderItem) {
+                return .all
+            }
+
+            let explicit = fileIds.reduce(into: 0) { count, id in
                 if selectedItemIds.contains(id) { count += 1 }
             }
 
-            if selectedCount == 0 { return .none }
-            if selectedCount == snapshot.itemIds.count { return .all }
-            return .partial
+            if explicit == 0 {
+                if selectedItemIds.contains(folderItem.id) {
+                    return hasDeselectionOverrideUnder(prefixOf: folderItem) ? .partial : .all
+                }
+                return .none
+            }
+
+            return (explicit == fileIds.count) ? .all : .partial
         }
         
         // For expanded folders, calculate based on per-child state so mixed selections stay accurate
@@ -700,7 +731,7 @@ final class ContentManager {
 
         // Files are fully selected only when their UUID is tracked in the selection set
         for file in fileChildren {
-            if selectedItemIds.contains(file.id) {
+            if isSelected(effectively: file) {
                 anySelection = true
             } else {
                 allFullySelected = false

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -152,7 +152,7 @@ final class ContentManager {
             }
         }
         if !needsPrefetch.isEmpty {
-            scheduleHiddenSelectionPrefetch(for: needsPrefetch)
+            scheduleHiddenSelectionPrefetch(for: needsPrefetch, force: true)
         }
 
         markSelectedDirty()
@@ -1222,8 +1222,8 @@ extension ContentManager {
 }
 
 extension ContentManager {
-    private func scheduleHiddenSelectionPrefetch(for ids: Set<UUID>) {
-        let newRequests = ids.subtracting(_pendingHiddenFetch)
+    private func scheduleHiddenSelectionPrefetch(for ids: Set<UUID>, force: Bool = false) {
+        let newRequests: Set<UUID> = force ? ids : ids.subtracting(_pendingHiddenFetch)
         guard !newRequests.isEmpty else { return }
 
         _pendingHiddenFetch.formUnion(newRequests)


### PR DESCRIPTION
## Summary
- Tri-state handling, hidden selection caching, and expanded-folder selection now match the desired behaviour
- Collapsed parents ignore folder rows and respect deselection overrides  
- Cache clears keep still-selected items visible until refresh completes
- Effective selection drives expanded rows so "All" appears immediately

## Changes
- **ContentManager.swift:144** - Keep hidden selections for IDs that remain selected, requeue them for prefetch, and prevents the Aggregated tab from momentarily dropping rows
- **ContentManager.swift:392** - Add `hasDeselectionOverrideUnder` helper so collapsed-folder math can detect explicit deselections beneath a selected parent
- **ContentManager.swift:693** - Recalculate collapsed-folder state using only file descendants, plus the new helper, yielding the correct All/Partial when subfolders are present  
- **ContentManager.swift:733** - Switch expanded views to `isSelected(effectively:)`, honoring ancestor selections while materialization finishes

## Test plan
- [ ] Test collapsed folder selection states show correct All/Partial/None indicators
- [ ] Verify hidden selections remain visible in Aggregated tab during cache refresh
- [ ] Check that deselection overrides are properly detected in nested folder structures
- [ ] Confirm expanded folder views honor ancestor selections immediately

🤖 Generated with [Claude Code](https://claude.ai/code)