### PR TITLE
Update default window size to landscape orientation

### DIFF
--- a/nozzle/Extensions/Defaults.Keys+Names.swift
+++ b/nozzle/Extensions/Defaults.Keys+Names.swift
@@ -68,7 +68,7 @@ extension Defaults.Keys {
   static let size = Key<Int>("historySize", default: 200)
   static let sortBy = Key<Sorter.By>("sortBy", default: .lastCopiedAt)
   static let suppressClearAlert = Key<Bool>("suppressClearAlert", default: false)
-  static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 450, height: 800))
+  static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 756, height: 307))
   static let windowPosition = Key<NSPoint>("windowPosition", default: NSPoint(x: 0.5, y: 0.8))
   static let showApplicationIcons = Key<Bool>("showApplicationIcons", default: true)
   


### PR DESCRIPTION
## Summary
• Updates default panel size from 450×800 to 756×307 pixels
• Changes from portrait to landscape orientation for better user experience
• Matches current user preferences for wider, shorter window layout

## Test plan
- [ ] Verify new users get 756×307 default window size
- [ ] Confirm existing users retain their current window dimensions
- [ ] Test window resizing still works properly

🤖 Generated with [Claude Code](https://claude.ai/code)