### PR TITLE
Remove visual command + number shortcut indicators from list view

### DIFF
--- a/nozzle/Views/ListItemView.swift
+++ b/nozzle/Views/ListItemView.swift
@@ -121,15 +121,7 @@ struct ListItemView<Title: View>: View {
       // Copy button, checkbox, or Command shortcut
       if showCheckbox {
         ZStack {
-          if modifierFlags.flags.contains(.command) && !shortcuts.isEmpty {
-            // Show shortcut when Command is held (replaces checkmark)
-            ForEach(shortcuts) { shortcut in
-              KeyboardShortcutView(shortcut: shortcut)
-                .opacity(shortcut.isVisible(shortcuts, modifierFlags.flags) ? 1 : 0)
-            }
-            .padding(.trailing, 20)
-            .frame(maxWidth: .infinity, alignment: .trailing)
-          } else if isSelected {
+          if isSelected {
             // Show round checkbox when item is selected
             Image(systemName: selectionSymbol)
               .font(.system(size: 14))


### PR DESCRIPTION
## Summary
Remove the visual shortcut indicators (⌘1, ⌘2, etc.) that appear when users hold down the Command key while viewing list items.

## Changes
- Modified `ListItemView.swift` to remove the conditional logic that displays `KeyboardShortcutView` when Command is held
- Keyboard shortcuts (Command+1, Command+2, etc.) still function normally
- Provides a cleaner interface without visual clutter

## Test plan
- [ ] Verify Command+number shortcuts still work for selecting items
- [ ] Confirm shortcut indicators no longer appear when holding Command
- [ ] Check that normal selection states (checkboxes, hover states) still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)