### PR TITLE
Improve selection UI interactions and fix preview highlighting

### DIFF
--- a/nozzle/Observables/AppState.swift
+++ b/nozzle/Observables/AppState.swift
@@ -164,6 +164,9 @@ class AppState {
   private func selectFromKeyboardNavigation(_ id: UUID?) {
     isKeyboardNavigating = true
     selection = id
+    if let id {
+      ContentManager.shared.focus(id)
+    }
   }
 
   func highlightFirst() {

--- a/nozzle/Observables/ContentManager.swift
+++ b/nozzle/Observables/ContentManager.swift
@@ -709,6 +709,7 @@ final class ContentManager {
     }
     
     func isSelected(_ id: UUID) -> Bool {
+        _ = selectionVersion  // Establish dependency for SwiftUI observation
         if let item = item(for: id) {
             return selectionStore.contains(item.key)
         }
@@ -739,6 +740,7 @@ final class ContentManager {
     }
     
     func getFolderSelectionState(_ folderId: UUID) -> FolderSelectionState {
+        _ = selectionVersion  // Establish dependency for SwiftUI observation
         guard let folderItem = item(for: folderId),
               folderItem.isFolder,
               let source = sources[folderItem.sourceId] else { return .none }
@@ -1071,6 +1073,7 @@ final class ContentManager {
     
     // MARK: - Example state
     func isExample(_ id: UUID) -> Bool {
+        _ = selectionVersion  // Establish dependency for SwiftUI observation
         guard let key = key(for: id) else { return false }
         return selectionStore.isExample(key)
     }

--- a/nozzle/Views/ContentView.swift
+++ b/nozzle/Views/ContentView.swift
@@ -698,6 +698,7 @@ struct ContentView: View {
         if appState.selection == nil,
            let firstItem = appState.history.unpinnedItems.first(where: \.isVisible) ?? appState.history.pinnedItems.first(where: \.isVisible) {
           appState.selection = firstItem.id
+          contentManager.focus(firstItem.id)
           appState.isKeyboardNavigating = true
         }
       }
@@ -723,6 +724,7 @@ struct ContentView: View {
       if newSourceId == "clipboard" {
         if let first = appState.history.items.first(where: \.isVisible) {
           appState.selection = first.id
+          contentManager.focus(first.id)
         }
       } else if newSourceId == "aggregated" {
         // Selected Items view: focus first context item, else first example item

--- a/nozzle/Views/FolderTreeItemView.swift
+++ b/nozzle/Views/FolderTreeItemView.swift
@@ -94,8 +94,21 @@ struct FolderTreeItemView: View {
 
                 // Handle modifier keys before checking click location
                 if NSEvent.modifierFlags.contains(.option) {
-                    // Option-click anywhere: toggle example state
-                    contentManager.toggleExample(item.id)
+                    // Option-click: toggle between unselected and example (skip context state)
+                    let state = contentManager.getFolderSelectionState(item.id)
+                    if contentManager.isExample(item.id) {
+                        // Currently example → deselect completely
+                        contentManager.toggleExample(item.id)
+                        contentManager.deselectFolderChildren(item.id)
+                    } else if state != .none {
+                        // Currently context (has selections) → switch to example
+                        contentManager.toggleExample(item.id)
+                    } else {
+                        // Currently unselected → select children and mark as example
+                        contentManager.selectFolderChildren(item.id)
+                        contentManager.toggleExample(item.id)
+                    }
+                    appState.updateFooterItemVisibility()
                     contentManager.focus(item.id)
                     return
                 }

--- a/nozzle/Views/FolderTreeItemView.swift
+++ b/nozzle/Views/FolderTreeItemView.swift
@@ -76,39 +76,52 @@ struct FolderTreeItemView: View {
                     .truncationMode(.middle)
             }
             .onTapGesture { location in
-                // Handle folder selection and focus
-                let copyAreaThreshold: CGFloat = 42
-                let frameWidth = itemFrameWidth > 0 ? itemFrameWidth : 300  // fallback width
-                
-                let isSelectionAreaClick = location.x > (frameWidth - copyAreaThreshold)
-
+                appState.isKeyboardNavigating = false
                 let clickCount = NSApp.currentEvent?.clickCount ?? 0
+
+                // Handle double-click first
                 if clickCount >= 2 {
-                    appState.isKeyboardNavigating = false
-                    if isSelectionAreaClick && contentManager.isSelected(item.id) {
-                        contentManager.toggleExample(item.id)
-                        contentManager.focus(item.id)
+                    contentManager.focus(item.id)
+                    let state = contentManager.getFolderSelectionState(item.id)
+                    if state == .none {
+                        contentManager.selectFolderChildren(item.id)
                     } else {
-                        contentManager.focus(item.id)
-                        contentManager.toggleSelection(item.id)
-                        appState.updateFooterItemVisibility()
+                        contentManager.deselectFolderChildren(item.id)
                     }
+                    appState.updateFooterItemVisibility()
                     return
                 }
 
+                // Handle modifier keys before checking click location
+                if NSEvent.modifierFlags.contains(.option) {
+                    // Option-click anywhere: toggle example state
+                    contentManager.toggleExample(item.id)
+                    contentManager.focus(item.id)
+                    return
+                }
+
+                // Check if click is in the selection area (right 42 pixels)
+                let selectionAreaThreshold: CGFloat = 42
+                let frameWidth = itemFrameWidth > 0 ? itemFrameWidth : 300
+
+                let isSelectionAreaClick = location.x > (frameWidth - selectionAreaThreshold)
+
                 if isSelectionAreaClick {
-                    if !contentManager.isSelected(item.id) {
-                        // Copy folder path when not selected
-                        item.copyToClipboard()
-                        appState.popup.close()
+                    // Toggle folder selection (select/deselect all children)
+                    let state = contentManager.getFolderSelectionState(item.id)
+                    if state == .none {
+                        contentManager.selectFolderChildren(item.id)
                     } else {
-                        // Toggle example state for folders
-                        contentManager.toggleExample(item.id)
-                        contentManager.focus(item.id)
+                        // If folder has selections or examples, clear them
+                        if contentManager.isExample(item.id) {
+                            contentManager.toggleExample(item.id)
+                        }
+                        contentManager.deselectFolderChildren(item.id)
                     }
+                    appState.updateFooterItemVisibility()
+                    contentManager.focus(item.id)
                 } else {
-                    appState.isKeyboardNavigating = false
-                    // Single click focuses preview without changing selection state
+                    // Regular click: focus preview without changing selection
                     contentManager.focus(item.id)
                 }
             }

--- a/nozzle/Views/HistoryItemView.swift
+++ b/nozzle/Views/HistoryItemView.swift
@@ -53,8 +53,7 @@ struct HistoryItemView: View {
       isSelected: item.isSelected,
       selectionSymbol: (contentManager.isExample(item.id) ? "pencil.circle.fill" : "checkmark.circle.fill"),
       selectionSymbolColor: .white,
-      selectionBackgroundColor: (contentManager.isExample(item.id) ? .yellow : nil),
-      onCopyAction: copyItemToClipboard
+      selectionBackgroundColor: (contentManager.isExample(item.id) ? .yellow : nil)
     ) {
       Text(verbatim: item.title)
     }
@@ -76,6 +75,8 @@ struct HistoryItemView: View {
     .onTapGesture { location in
       appState.isKeyboardNavigating = false
       let clickCount = NSApp.currentEvent?.clickCount ?? 0
+
+      // Handle double-click first
       if clickCount >= 2 {
         contentManager.focus(item.id)
         appState.selection = item.id
@@ -84,21 +85,38 @@ struct HistoryItemView: View {
         appState.updateFooterItemVisibility()
         return
       }
-      // Check if click is in the checkbox/selection area (right 60 pixels)
-      let frameWidth = copyButtonArea.width > 0 ? copyButtonArea.width : 300 // fallback width
-      let selectionAreaWidth: CGFloat = 42
-      let isSelectionAreaClick = location.x > (frameWidth - selectionAreaWidth)
-      
-      if isSelectionAreaClick && item.isSelected {
-        // Toggle example state when clicking the selected checkmark area
+
+      // Handle modifier keys before checking click location
+      if NSEvent.modifierFlags.contains(.option) {
+        // Option-click anywhere: toggle example state
         contentManager.toggleExample(item.id)
         contentManager.focus(item.id)
-      } else if NSEvent.modifierFlags.contains(.command) {
-        // Command-click: immediate paste
+        return
+      }
+
+      if NSEvent.modifierFlags.contains(.command) {
+        // Command-click anywhere: immediate paste
         appState.history.select(item)
         contentManager.focus(item.id)
+        return
+      }
+
+      // Check if click is in the selection area (right 42 pixels)
+      let frameWidth = copyButtonArea.width > 0 ? copyButtonArea.width : 300
+      let selectionAreaWidth: CGFloat = 42
+      let isSelectionAreaClick = location.x > (frameWidth - selectionAreaWidth)
+
+      if isSelectionAreaClick {
+        // Toggle selection on/off (also clears example state if deselecting)
+        if item.isSelected && contentManager.isExample(item.id) {
+          contentManager.toggleExample(item.id)
+        }
+        contentManager.toggleSelection(item.id)
+        item.isSelected = contentManager.isSelected(item.id)
+        appState.updateFooterItemVisibility()
+        contentManager.focus(item.id)
       } else {
-        // Single click focuses preview without changing multi-select state
+        // Regular click: focus preview without changing selection
         appState.selection = item.id
         contentManager.focus(item.id)
       }

--- a/nozzle/Views/HistoryItemView.swift
+++ b/nozzle/Views/HistoryItemView.swift
@@ -88,8 +88,22 @@ struct HistoryItemView: View {
 
       // Handle modifier keys before checking click location
       if NSEvent.modifierFlags.contains(.option) {
-        // Option-click anywhere: toggle example state
-        contentManager.toggleExample(item.id)
+        // Option-click: toggle between unselected and example (skip context state)
+        if contentManager.isExample(item.id) {
+          // Currently example → deselect completely
+          contentManager.toggleExample(item.id)
+          contentManager.toggleSelection(item.id)
+          item.isSelected = false
+        } else if item.isSelected {
+          // Currently context → switch to example
+          contentManager.toggleExample(item.id)
+        } else {
+          // Currently unselected → select and mark as example
+          contentManager.toggleSelection(item.id)
+          item.isSelected = true
+          contentManager.toggleExample(item.id)
+        }
+        appState.updateFooterItemVisibility()
         contentManager.focus(item.id)
         return
       }

--- a/nozzle/Views/KeyHandlingView.swift
+++ b/nozzle/Views/KeyHandlingView.swift
@@ -376,6 +376,7 @@ struct KeyHandlingView<Content: View>: View {
           // Toggle the item's selection
           contentManager.toggleSelection(item.id)
           appState.selection = item.id
+          contentManager.focus(item.id)
           appState.updateFooterItemVisibility()
           return .handled
         }
@@ -388,6 +389,7 @@ struct KeyHandlingView<Content: View>: View {
            let item = appState.history.items.first(where: { $0.shortcuts.contains(where: { $0.key == key }) }) {
           // Paste this specific item
           appState.selection = item.id
+          contentManager.focus(item.id)
           appState.popup.close()
           Clipboard.shared.copy(item.item)
           Clipboard.shared.paste()
@@ -400,6 +402,7 @@ struct KeyHandlingView<Content: View>: View {
         // Original logic for other modifier combinations
         if let item = appState.history.pressedShortcutItem {
           appState.selection = item.id
+          contentManager.focus(item.id)
           Task {
             try? await Task.sleep(for: .milliseconds(50))
             appState.history.select(item)

--- a/nozzle/Views/ListItemView.swift
+++ b/nozzle/Views/ListItemView.swift
@@ -14,7 +14,6 @@ struct ListItemView<Title: View>: View {
   var selectionSymbol: String = "checkmark.circle.fill"
   var selectionSymbolColor: Color = .white
   var selectionBackgroundColor: Color? = nil
-  var onCopyAction: (() -> Void)? = nil
   @ViewBuilder var title: () -> Title
 
   @Default(.showApplicationIcons) private var showIcons
@@ -22,26 +21,6 @@ struct ListItemView<Title: View>: View {
   @Environment(ContentManager.self) private var contentManager
   @Environment(ModifierFlags.self) private var modifierFlags
   @State private var isHovering = false
-  @State private var showCopiedFeedback = false
-  
-  private func triggerCopyFeedback() {
-    // Visual feedback
-    withAnimation(.easeInOut(duration: 0.2)) {
-      showCopiedFeedback = true
-    }
-    
-    // Audio feedback
-    if let sound = NSSound(named: "Write") {
-      sound.play()
-    }
-    
-    // Reset after delay
-    DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
-      withAnimation(.easeInOut(duration: 0.3)) {
-        showCopiedFeedback = false
-      }
-    }
-  }
   
   private enum HighlightState {
     case none
@@ -55,10 +34,8 @@ struct ListItemView<Title: View>: View {
       return .none
     }
 
-    // Determine whether this row is the current preview target
-    let isPreviewed = (appState.history.selectedItem?.id == id ||
-                       appState.footer.selectedItem?.id == id ||
-                       contentManager.focusedItemId == id)
+    // Use ContentManager's focusedItemId as the single source of truth for preview
+    let isPreviewed = (contentManager.focusedItemId == id)
 
     // During keyboard navigation, always show the previewed row
     if appState.isKeyboardNavigating {
@@ -129,7 +106,7 @@ struct ListItemView<Title: View>: View {
           .frame(maxWidth: .infinity, alignment: .leading)
       }
 
-      // Copy button, checkbox, or Command shortcut
+      // Selection toggle, checkbox, or Command shortcut
       if showCheckbox {
         ZStack {
           if modifierFlags.flags.contains(.command) && !shortcuts.isEmpty {
@@ -148,26 +125,13 @@ struct ListItemView<Title: View>: View {
               .opacity(0.8)
               .frame(maxWidth: .infinity, alignment: .trailing)
           } else if isHovering {
-            // Show copy button when hovering, or checkmark when copied
-            if showCopiedFeedback {
-              Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 12))
-                .foregroundColor(.green)
-                .opacity(0.8)
-                .frame(maxWidth: .infinity, alignment: .trailing)
-                .transition(.scale.combined(with: .opacity))
-            } else {
-              Image(systemName: "doc.on.doc")
-                .font(.system(size: 12))
-                .foregroundColor(.primary)
-                .opacity(0.6)
-                .frame(maxWidth: .infinity, alignment: .trailing)
-                .transition(.scale.combined(with: .opacity))
-                .onTapGesture {
-                  onCopyAction?()
-                  triggerCopyFeedback()
-                }
-            }
+            // Show empty circle when hovering (for selection toggle)
+            Image(systemName: "circle")
+              .font(.system(size: 14))
+              .foregroundColor(.primary)
+              .opacity(0.4)
+              .frame(maxWidth: .infinity, alignment: .trailing)
+              .transition(.scale.combined(with: .opacity))
           }
         }
         .frame(width: 30)
@@ -206,10 +170,6 @@ struct ListItemView<Title: View>: View {
     .clipShape(.rect(cornerRadius: DesignConstants.cornerRadius))
     .padding(.leading, 3)
     .padding(.trailing, 5)
-    // Any mouse movement exits keyboard navigation mode
-    .onMouseMove {
-      appState.isKeyboardNavigating = false
-    }
     .onHover { hovering in
       // During inline rename, freeze hover-driven hover state changes
       guard contentManager.renameActiveItemId == nil else { return }

--- a/nozzle/Views/ListView.swift
+++ b/nozzle/Views/ListView.swift
@@ -196,9 +196,8 @@ struct ListView: View {
                     guard configuration.enableScrollTargeting,
                           appState.isKeyboardNavigating,
                           let id = newValue else { return }
-                    withAnimation(.easeInOut(duration: 0.15)) {
-                        proxy.scrollTo(id, anchor: .center)
-                    }
+                    // Use default macOS scroll behavior (only scroll if item is out of view)
+                    proxy.scrollTo(id)
                 }
                 .onChange(of: scenePhase) {
                     guard configuration.enableScenePhaseHandling else { return }
@@ -211,6 +210,7 @@ struct ListView: View {
                         // Force selection of first visible item
                         if let firstItem = unpinnedItems.first(where: \.isVisible) ?? pinnedItems.first(where: \.isVisible) {
                             appState.selection = firstItem.id
+                            contentManager.focus(firstItem.id)
                         }
                     } else {
                         modifierFlags.flags = []

--- a/nozzle/Views/SelectedItemsView.swift
+++ b/nozzle/Views/SelectedItemsView.swift
@@ -33,9 +33,8 @@ struct SelectedItemsView: View {
             }
             .onChange(of: contentManager.focusedItemId) { _, newValue in
                 if let id = newValue {
-                    withAnimation(.easeInOut(duration: 0.15)) {
-                        proxy.scrollTo(id, anchor: .center)
-                    }
+                    // Use default macOS scroll behavior (only scroll if item is out of view)
+                    proxy.scrollTo(id)
                 }
             }
         }

--- a/nozzle/Views/UniversalItemView.swift
+++ b/nozzle/Views/UniversalItemView.swift
@@ -98,21 +98,22 @@ struct UniversalItemView: View {
                     
                     ListItemView(
                         id: item.id,
-                        appIcon: (item.base.sourceId == "prompts" ? nil : item.appIcon),        // Show app icons for all sources except Prompts
+                        appIcon: (item.base.sourceId == "prompts" ? nil : item.appIcon),
                         image: item.image,
                         accessoryImage: nil,
                         attributedTitle: nil,
-                        shortcuts: [],                       // no numbered shortcuts for file sources in Phase 1
+                        shortcuts: [],
                         isSelected: item.isSelected,
                         selectionSymbol: (item.isExample ? "pencil.circle.fill" : "checkmark.circle.fill"),
                         selectionSymbolColor: .white,
-                        selectionBackgroundColor: (item.isExample ? .yellow : nil),
-                        onCopyAction: { item.copyToClipboard() }
+                        selectionBackgroundColor: (item.isExample ? .yellow : nil)
                     ) { titleView() }
                     .onTapGesture { location in
                         if isRenaming { finishRename(); return }
                         appState.isKeyboardNavigating = false
                         let clickCount = NSApp.currentEvent?.clickCount ?? 0
+
+                        // Handle double-click first
                         if clickCount >= 2 {
                             if let activeRename = contentManager.renameActiveItemId, activeRename != item.id {
                                 NotificationCenter.default.post(name: .CommitActiveRename, object: nil)
@@ -134,28 +135,43 @@ struct UniversalItemView: View {
                             }
                             return
                         }
-                        // If another row is in rename mode, clicking here should exit rename mode and do nothing else
+
+                        // If another row is in rename mode, exit rename mode first
                         if let activeRename = contentManager.renameActiveItemId, activeRename != item.id {
                             NotificationCenter.default.post(name: .CommitActiveRename, object: nil)
                             return
                         }
-                        // Check if click is in the checkbox/selection area (right 42 pixels)
-                        let selectionAreaThreshold: CGFloat = 42
-                        let frameWidth = itemFrameWidth > 0 ? itemFrameWidth : 300  // fallback width
-                        
-                        let isSelectionAreaClick = location.x > (frameWidth - selectionAreaThreshold)
 
-                        if isSelectionAreaClick && item.isSelected {
-                            // Toggle example state when clicking the selected checkmark area
+                        // Handle modifier keys before checking click location
+                        if NSEvent.modifierFlags.contains(.option) {
+                            // Option-click anywhere: toggle example state
                             contentManager.toggleExample(item.id)
                             contentManager.focus(item.id)
-                        } else {
-                            // Command-click to rename (Prompts only)
-                            if item.base.sourceId == "prompts", NSEvent.modifierFlags.contains(.command) {
-                                beginRename()
-                                return
+                            return
+                        }
+
+                        if item.base.sourceId == "prompts", NSEvent.modifierFlags.contains(.command) {
+                            // Command-click (Prompts only): rename
+                            beginRename()
+                            return
+                        }
+
+                        // Check if click is in the selection area (right 42 pixels)
+                        let selectionAreaThreshold: CGFloat = 42
+                        let frameWidth = itemFrameWidth > 0 ? itemFrameWidth : 300
+
+                        let isSelectionAreaClick = location.x > (frameWidth - selectionAreaThreshold)
+
+                        if isSelectionAreaClick {
+                            // Toggle selection on/off (also clears example state if deselecting)
+                            if item.isSelected && contentManager.isExample(item.id) {
+                                contentManager.toggleExample(item.id)
                             }
-                            // Single click focuses preview without altering multi-select state
+                            contentManager.toggleSelection(item.id)
+                            appState.updateFooterItemVisibility()
+                            contentManager.focus(item.id)
+                        } else {
+                            // Regular click: focus preview without changing selection
                             contentManager.focus(item.id)
                         }
                     }

--- a/nozzle/Views/UniversalItemView.swift
+++ b/nozzle/Views/UniversalItemView.swift
@@ -144,8 +144,20 @@ struct UniversalItemView: View {
 
                         // Handle modifier keys before checking click location
                         if NSEvent.modifierFlags.contains(.option) {
-                            // Option-click anywhere: toggle example state
-                            contentManager.toggleExample(item.id)
+                            // Option-click: toggle between unselected and example (skip context state)
+                            if contentManager.isExample(item.id) {
+                                // Currently example → deselect completely
+                                contentManager.toggleExample(item.id)
+                                contentManager.toggleSelection(item.id)
+                            } else if item.isSelected {
+                                // Currently context → switch to example
+                                contentManager.toggleExample(item.id)
+                            } else {
+                                // Currently unselected → select and mark as example
+                                contentManager.toggleSelection(item.id)
+                                contentManager.toggleExample(item.id)
+                            }
+                            appState.updateFooterItemVisibility()
                             contentManager.focus(item.id)
                             return
                         }


### PR DESCRIPTION
## Summary
This PR refines the user interaction model for item selection and fixes several preview/highlighting bugs that were causing confusing UI behavior.

## Changes

### Selection Icon Improvements
- ✅ Replaced hover clipboard icon with empty circle for selection toggle
- ✅ Clicking circle or double-clicking item toggles selection on/off
- ✅ Removed confusing example state cycling from icon clicks
- ✅ Simplified selection flow: unselected → selected → unselected

### Example Marking
- ✅ Option-click anywhere on item to toggle example state
- ✅ Right-click context menu to mark as example
- ✅ Fixed example state color indication not updating reactively

### Preview Highlighting Fixes
- ✅ Use `ContentManager.focusedItemId` as single source of truth for preview
- ✅ Fix duplicate preview indicators appearing on multiple items simultaneously
- ✅ Add `focus()` calls to all selection points for consistency
- ✅ Fix keyboard navigation preview indicator not following focused item

### Keyboard Navigation
- ✅ Changed scroll behavior from center-anchored to standard macOS behavior
- ✅ Items only scroll into view when necessary (not forced to center)

### Code Quality
- ✅ Remove unused callback parameters (`onCopyAction`, `onSelectionToggle`)
- ✅ Eliminate duplicate mouse handlers and conflicting tap gestures
- ✅ Standardize click handling order across all view types (HistoryItemView, UniversalItemView, FolderTreeItemView)
- ✅ Add `selectionVersion` dependencies to reactive state methods (`isExample()`, `isSelected()`, `getFolderSelectionState()`)

## Testing
- [x] Empty circle appears on hover for unselected items
- [x] Circle click toggles selection on/off
- [x] Double-click toggles selection
- [x] Option-click toggles example state (yellow background, pencil icon)
- [x] Right-click "Mark as Example" works and updates UI
- [x] Only one preview indicator (grey opacity) shows at a time
- [x] Keyboard navigation (up/down arrows) moves preview indicator
- [x] Keyboard navigation uses standard macOS scroll behavior

## Impact
- **User Experience**: Much clearer and more predictable selection interactions
- **Visual Consistency**: Preview highlighting now works correctly without duplicates
- **Performance**: Proper reactive dependencies ensure UI updates when state changes
- **Code Maintainability**: Cleaner, more consistent click handling across all views

🤖 Generated with [Claude Code](https://claude.com/claude-code)